### PR TITLE
fixed cloning non-clonable items

### DIFF
--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -25,6 +25,19 @@ class DeepCopy
      */
     private $filters = [];
 
+    private $skipUncloneable = false;
+
+    /**
+     * Cloning uncloneable properties won't throw exception.
+     * @param $skipUncloneable
+     * @return $this
+     */
+    public function skipUncloneable($skipUncloneable = true)
+    {
+        $this->skipUncloneable = $skipUncloneable;
+        return $this;
+    }
+
     /**
      * Perform a deep copy of the object.
      * @param object $object
@@ -92,9 +105,9 @@ class DeepCopy
 
         $reflectedObject = new \ReflectionObject($object);
 
-        if (!$reflectedObject->isCloneable()) {
+        if (!$reflectedObject->isCloneable() and $this->skipUncloneable) {
             $this->hashMap[$objectHash] = $object;
-            return $object;            
+            return $object;
         }
 
         $newObject = clone $object;

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -95,7 +95,7 @@ class DeepCopyTest extends AbstractTestClass
     {
         $a = new \ReflectionClass('DeepCopyTest\A');
         $deepCopy = new DeepCopy();
-        $a2 = $deepCopy->copy($a);
+        $a2 = $deepCopy->skipUncloneable()->copy($a);
         $this->assertSame($a, $a2);
     }
 


### PR DESCRIPTION
I noticed an issue cloning object contained a \ReflectionClass instance.
Thus, I added a check if object is cloneable before cloning it. 
