### PR TITLE
Add DataFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,24 @@ $myCopy = $deepCopy->copy($myObject);
 // $myCopy->category has not been touched
 ```
 
+### `DataFilter`
+
+If you want modify data of property like value of an array you can use the `DataFilter`.
+
+```php
+$deepCopy = new DeepCopy();
+$callback = function($data) { 
+    $data['options']['option1'] = false; return $data;
+};
+$deepCopy->addFilter(new DataFilter($callback), new PropertyMatcher('MyClass', 'myProperty'));
+$myCopy = $deepCopy->copy($myObject);
+
+// $myCopy->myProperty will return data modified by your callback
+```
+
+**NOTE** : The "callback" parameter of the DataFilter constructor accepts any PHP callable.
+
+
 #### `DoctrineCollectionFilter`
 
 If you use Doctrine and want to copy an entity, you will need to use the `DoctrineCollectionFilter`:
@@ -152,7 +170,6 @@ $myCopy = $deepCopy->copy($myObject);
 
 // $myCopy->myProperty will return an empty collection
 ```
-
 
 ## Contributing
 

--- a/src/DeepCopy/Filter/DataFilter.php
+++ b/src/DeepCopy/Filter/DataFilter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace DeepCopy\Filter;
+
+class DataFilter implements Filter
+{
+    /**
+     * @var Callable
+     */
+    protected $callback;
+
+    /**
+     * @param Callable $callable
+     */
+    public function __construct(Callable $callable)
+    {
+        $this->callback = $callable;
+    }
+
+    /**
+     * Apply the filter to the object.
+     *
+     * @param object   $object
+     * @param string   $property
+     * @param Callable $objectCopier
+     */
+    public function apply($object, $property, $objectCopier)
+    {
+        $reflectionProperty = new \ReflectionProperty($object, $property);
+        $reflectionProperty->setAccessible(true);
+
+        if ($this->callback instanceof \Closure) { //Avoid call_user_func if we can
+            $value = $this->callback->__invoke($reflectionProperty->getValue($object));
+        } else {
+            $value = call_user_func($this->callback, $reflectionProperty->getValue($object));
+        }
+
+        $reflectionProperty->setValue($object, $value);
+    }
+}

--- a/tests/DeepCopyTest/Filter/DataFilterTest.php
+++ b/tests/DeepCopyTest/Filter/DataFilterTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace DeepCopyTest\Filter;
+
+use DeepCopy\DeepCopy;
+use DeepCopy\Filter\DataFilter;
+use DeepCopy\Matcher\PropertyMatcher;
+
+class DataFilterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider handlerProvider
+     */
+    public function testApply(Callable $callback, Array $expected)
+    {
+        $object = new \stdClass();
+        $object->data = array('foo' => 'bar', 'baz' => 'foo');
+
+        $filter = new DataFilter($callback);
+
+        $filter->apply($object, 'data', function($item) {
+            return null;
+        });
+
+        $this->assertEquals($expected, $object->data);
+    }
+
+    public function handlerProvider()
+    {
+        $closure = function($data) {
+            unset($data['baz']);
+            return $data;
+        };
+
+        return array(
+            array($closure, array('foo' => 'bar')),
+            array('DeepCopyTest\Filter\Callback::copy', array('foo' => 'bar', 'baz' => 'foo', 'foobar' => 'baz')),
+            array(array(new Callback(), 'callback'), array('foo' => 'foo'))
+        );
+    }
+
+    public function testIntegration()
+    {
+        //Prepare object to copy
+        $object = new \StdClass();
+        $object->data = array(
+            'foo' => 'bar',
+            'baz' => array('bar' => 'foo'),
+            'bar' => 'foo'
+        );
+
+        //Copy
+        $deepCopy = new DeepCopy();
+        $deepCopy->addFilter(new DataFilter(function($data) {
+            $data['baz']['bar'] = 'dummy_change';
+            unset($data['bar']);
+
+            return $data;
+        }), new PropertyMatcher(get_class($object), 'data'));
+
+        $copied = $deepCopy->copy($object);
+
+        //Check copied
+        $this->assertEquals(array(
+            'foo' => 'bar',
+            'baz' => array('bar' => 'dummy_change')
+        ), $copied->data);
+
+        //Check original object is unchanged
+        $this->assertEquals(
+            array('foo' => 'bar', 'baz' => array('bar' => 'foo'), 'bar' => 'foo'),
+            $object->data
+        );
+    }
+}
+
+class Callback
+{
+    public static function copy($data)
+    {
+        $data['foobar'] = 'baz';
+        return $data;
+    }
+
+    public function callback($data)
+    {
+        return array('foo' => 'foo');
+    }
+}


### PR DESCRIPTION
Add new filter, In the way to handle data property (refer to readme.md changed for more details).

My use case : I have to copy doctrine entity object who contains a JsonArray property, I must set some  values to false and let unchanged others.

I know we can achieve this without DeepCopy but in order to keep the code simple as possible and consistency, retrieve a real clean and formed copied object directly without implement something like "AfterObjectDuplication" to changed some property wich can be done during the process is better IMO.
