### PR TITLE
DeepCopy: Support for copying private properties of ancestor objects

### DIFF
--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -6,6 +6,7 @@ use DeepCopy\Exception\CloneException;
 use DeepCopy\Filter\Filter;
 use DeepCopy\Matcher\Matcher;
 use ReflectionProperty;
+use DeepCopy\Reflection\ReflectionHelper;
 
 /**
  * DeepCopy
@@ -118,7 +119,7 @@ class DeepCopy
         $newObject = clone $object;
         $this->hashMap[$objectHash] = $newObject;
 
-        foreach ($reflectedObject->getProperties() as $property) {
+        foreach (ReflectionHelper::getProperties($reflectedObject) as $property) {
             $this->copyObjectProperty($newObject, $property);
         }
 

--- a/src/DeepCopy/Reflection/ReflectionHelper.php
+++ b/src/DeepCopy/Reflection/ReflectionHelper.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace DeepCopy\Reflection;
+
+class ReflectionHelper
+{
+    /**
+     * Retrieves all properties (including private ones), from object and all its ancestors.
+     *
+     * Standard \ReflectionClass->getProperties() does not return private properties from ancestor classes.
+     *
+     * @author muratyaman@gmail.com
+     * @see http://php.net/manual/en/reflectionclass.getproperties.php
+     *
+     * @param \ReflectionClass $ref
+     * @return \ReflectionProperty[]
+     */
+    public static function getProperties(\ReflectionClass $ref)
+    {
+        $props = $ref->getProperties();
+        $propsArr = array();
+
+        foreach ($props as $prop) {
+            $f = $prop->getName();
+            $propsArr[$f] = $prop;
+        }
+
+        if ($parentClass = $ref->getParentClass()) {
+            $parentPropsArr = self::getProperties($parentClass);
+            if (count($parentPropsArr) > 0) {
+                $propsArr = array_merge($parentPropsArr, $propsArr);
+            }
+        }
+        return $propsArr;
+    }
+}

--- a/tests/DeepCopyTest/AbstractTestClass.php
+++ b/tests/DeepCopyTest/AbstractTestClass.php
@@ -2,6 +2,8 @@
 
 namespace DeepCopyTest;
 
+use DeepCopy\Reflection\ReflectionHelper;
+
 /**
  * Abstract test class
  */
@@ -34,7 +36,7 @@ abstract class AbstractTestClass extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(get_class($expected), $actual);
 
         $class = new \ReflectionClass($actual);
-        foreach ($class->getProperties() as $property) {
+        foreach (ReflectionHelper::getProperties($class) as $property) {
             $property->setAccessible(true);
             $this->assertDeepCopyOf($property->getValue($expected), $property->getValue($actual));
         }

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -39,6 +39,17 @@ class DeepCopyTest extends AbstractTestClass
         $this->assertDeepCopyOf($o, $deepCopy->copy($o));
     }
 
+    public function testPrivatePropertyOfParentObjectCopy()
+    {
+        $o = new E();
+        $o->setProperty1(new B);
+        $o->setProperty2(new B);
+
+        $deepCopy = new DeepCopy();
+
+        $this->assertDeepCopyOf($o, $deepCopy->copy($o));
+    }
+
     public function testPropertyArrayCopy()
     {
         $o = new A();
@@ -175,4 +186,36 @@ class B
 class C
 {
     private function __clone(){}
+}
+
+class D
+{
+    private $property1;
+
+    public function getProperty1()
+    {
+        return $this->property1;
+    }
+
+    public function setProperty1($property1)
+    {
+        $this->property1 = $property1;
+        return $this;
+    }
+}
+
+class E extends D
+{
+    private $property2;
+
+    public function getProperty2()
+    {
+        return $this->property2;
+    }
+
+    public function setProperty2($property2)
+    {
+        $this->property2 = $property2;
+        return $this;
+    }
 }


### PR DESCRIPTION
Since `\ReflectionClass::getProperties()` does not return private properties of parent classes, calling `$deepCopy->copy()` on object extending from class with private properties resulted to incomplete deep copy.