### PR TITLE
Implemented filter that processes all alements by type

### DIFF
--- a/src/DeepCopy/Matcher/PropertyTypeMatcher.php
+++ b/src/DeepCopy/Matcher/PropertyTypeMatcher.php
@@ -6,6 +6,9 @@ use ReflectionProperty;
 
 /**
  * Match a property by its type
+ *
+ * @deprecated It is recommended to use {@see DeepCopy\TypeFilter\TypeFilter} instead, as it applies on all occurrences
+ *             of given type in copied context (eg. array elements), not just on object properties.
  */
 class PropertyTypeMatcher implements Matcher
 {

--- a/src/DeepCopy/TypeFilter/ReplaceFilter.php
+++ b/src/DeepCopy/TypeFilter/ReplaceFilter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace DeepCopy\TypeFilter;
+
+class ReplaceFilter implements TypeFilter
+{
+    /**
+     * @var callable
+     */
+    protected $callback;
+
+    /**
+     * @param callable $callable Will be called to get the new value for each element to replace
+     */
+    public function __construct(callable $callable)
+    {
+        $this->callback = $callable;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply($element)
+    {
+        return call_user_func($this->callback, $element);
+    }
+}

--- a/src/DeepCopy/TypeFilter/ShallowCopyFilter.php
+++ b/src/DeepCopy/TypeFilter/ShallowCopyFilter.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace DeepCopy\TypeFilter;
+
+class ShallowCopyFilter implements TypeFilter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function apply($element)
+    {
+        return clone $element;
+    }
+}

--- a/src/DeepCopy/TypeFilter/TypeFilter.php
+++ b/src/DeepCopy/TypeFilter/TypeFilter.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace DeepCopy\TypeFilter;
+
+interface TypeFilter
+{
+    /**
+     * Apply the filter to the object.
+     * @param mixed $element
+     */
+    public function apply($element);
+}

--- a/src/DeepCopy/TypeMatcher/TypeMatcher.php
+++ b/src/DeepCopy/TypeMatcher/TypeMatcher.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace DeepCopy\TypeMatcher;
+
+/**
+ * TypeMatcher class
+ */
+class TypeMatcher
+{
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @param string $type
+     */
+    public function __construct($type)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * @param $element
+     * @return boolean
+     */
+    public function matches($element)
+    {
+        return is_object($element) ? is_a($element, $this->type) : gettype($element) === $this->type;
+    }
+}


### PR DESCRIPTION
Since original `Matcher` and `Filter` applies only to object memebers, I've implemented custom `TypeMatcher` and `TypeFilter` and updated `recursiveCopy()` accordingly. This new `TypeMatcher` process really all elements in tree, even if they are array members or it is a root node.

I've also marked `PropertyTypeMatcher` as deprecated, since it is no longer needed.
 
Fixes #24