### PR TITLE
Fix for Exception

### DIFF
--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -134,7 +134,7 @@ class DeepCopy
         if (false === $isCloneable) {
             throw new CloneException(sprintf(
                 'Class "%s" is not cloneable.',
-                $object->getName()
+                $reflectedObject->getName()
             ));
         }
 

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -123,7 +123,7 @@ class DeepCopyTest extends AbstractTestClass
      */
     public function testCloneException()
     {
-        $o = new \ReflectionClass('DeepCopyTest\C');
+        $o = new C;
         $deepCopy = new DeepCopy();
         $deepCopy->copy($o);
     }


### PR DESCRIPTION
We cannot assume that EVERY object we receive here implements the getName method. Therefore we should fall back to the ReflectionObject which implements the method (via ReflectionClass).