### PR TITLE
Fix Doctrine Proxy issues

### DIFF
--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -6,7 +6,7 @@ use DeepCopy\Exception\CloneException;
 use DeepCopy\Filter\Filter;
 use DeepCopy\Matcher\Matcher;
 use DeepCopy\TypeFilter\TypeFilter;
-use DeepCopy\TypeMatcher\TypeMatcher;
+use DeepCopy\TypeMatcher\TypeMatcherInterface;
 use ReflectionProperty;
 use DeepCopy\Reflection\ReflectionHelper;
 
@@ -65,7 +65,7 @@ class DeepCopy
         ];
     }
 
-    public function addTypeFilter(TypeFilter $filter, TypeMatcher $matcher)
+    public function addTypeFilter(TypeFilter $filter, TypeMatcherInterface $matcher)
     {
         $this->typeFilters[] = [
             'matcher' => $matcher,
@@ -194,7 +194,7 @@ class DeepCopy
         $matched = $this->first(
             $filterRecords,
             function (array $record) use ($var) {
-                /* @var TypeMatcher $matcher */
+                /* @var TypeMatcherInterface $matcher */
                 $matcher = $record['matcher'];
 
                 return $matcher->matches($var);

--- a/src/DeepCopy/Reflection/ReflectionHelper.php
+++ b/src/DeepCopy/Reflection/ReflectionHelper.php
@@ -17,10 +17,22 @@ class ReflectionHelper
      */
     public static function getProperties(\ReflectionClass $ref)
     {
+        $isDoctrineProxy = false;
+        if (
+            interface_exists('Doctrine\Common\Persistence\Proxy') &&
+            $ref->implementsInterface('Doctrine\Common\Persistence\Proxy')
+        ) {
+            $isDoctrineProxy = true;
+        }
+
         $props = $ref->getProperties();
         $propsArr = array();
 
         foreach ($props as $prop) {
+            if ($isDoctrineProxy && !$ref->getParentClass()->hasProperty($prop->getName())) {
+                continue;
+            }
+
             $f = $prop->getName();
             $propsArr[$f] = $prop;
         }

--- a/src/DeepCopy/TypeFilter/KeepFilter.php
+++ b/src/DeepCopy/TypeFilter/KeepFilter.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace DeepCopy\TypeFilter;
+
+class KeepFilter implements TypeFilter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function apply($element)
+    {
+        return $element;
+    }
+}

--- a/src/DeepCopy/TypeMatcher/Doctrine/DoctrineProxyNotCloneableTypeMatcher.php
+++ b/src/DeepCopy/TypeMatcher/Doctrine/DoctrineProxyNotCloneableTypeMatcher.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace DeepCopy\TypeMatcher\Doctrine;
+
+use DeepCopy\TypeMatcher\TypeMatcherInterface;
+use Doctrine\Common\Persistence\Proxy;
+use ReflectionObject;
+
+class DoctrineProxyNotCloneableTypeMatcher implements TypeMatcherInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function matches($element)
+    {
+        if (!is_object($element) || !$element instanceof Proxy) {
+            return false;
+        }
+
+        $reflectionObject = new ReflectionObject($element);
+
+        if ($isCloneable = $reflectionObject->getParentClass()->isCloneable()) {
+            $element->__load();
+        }
+
+        return !$isCloneable;
+    }
+}

--- a/src/DeepCopy/TypeMatcher/TypeMatcher.php
+++ b/src/DeepCopy/TypeMatcher/TypeMatcher.php
@@ -5,7 +5,7 @@ namespace DeepCopy\TypeMatcher;
 /**
  * TypeMatcher class
  */
-class TypeMatcher
+class TypeMatcher implements TypeMatcherInterface
 {
     /**
      * @var string
@@ -21,8 +21,7 @@ class TypeMatcher
     }
 
     /**
-     * @param $element
-     * @return boolean
+     * {@inheritdoc}
      */
     public function matches($element)
     {

--- a/src/DeepCopy/TypeMatcher/TypeMatcherInterface.php
+++ b/src/DeepCopy/TypeMatcher/TypeMatcherInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace DeepCopy\TypeMatcher;
+
+interface TypeMatcherInterface
+{
+    /**
+     * @param $element
+     *
+     * @return boolean
+     */
+    public function matches($element);
+}


### PR DESCRIPTION
See #18 

We can't reproduce the issue #18 with the Doctrine Proxy properties in our project (@mrthehud and @vbartusevicius can you please check if this PR solve your problems?)

But this PR solve the issue we have in our current project:
We have an entity we don't want to clone, using
```php
    protected function __clone()
    {
    }
```
When it is a Doctrine Proxy, `$reflectedObject->isCloneable()` always returns `true` (http://php.net/manual/en/reflectionclass.iscloneable.php)

Now (if it is a Doctrine Proxy) it will check if the parent class is cloneable.