### PR TITLE
Matchers & Filters: use the right ReflectionProperty

### DIFF
--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -162,10 +162,10 @@ class DeepCopy
             /** @var Filter $filter */
             $filter = $item['filter'];
 
-            if ($matcher->matches($object, $property->getName())) {
+            if ($matcher->matches($object, $property)) {
                 $filter->apply(
                     $object,
-                    $property->getName(),
+                    $property,
                     function ($object) {
                         return $this->recursiveCopy($object);
                     }

--- a/src/DeepCopy/Filter/Doctrine/DoctrineCollectionFilter.php
+++ b/src/DeepCopy/Filter/Doctrine/DoctrineCollectionFilter.php
@@ -13,10 +13,8 @@ class DoctrineCollectionFilter implements Filter
     /**
      * {@inheritdoc}
      */
-    public function apply($object, $property, $objectCopier)
+    public function apply($object, ReflectionProperty $reflectionProperty, $objectCopier)
     {
-        $reflectionProperty = new ReflectionProperty($object, $property);
-
         $reflectionProperty->setAccessible(true);
         $oldCollection = $reflectionProperty->getValue($object);
 

--- a/src/DeepCopy/Filter/Doctrine/DoctrineEmptyCollectionFilter.php
+++ b/src/DeepCopy/Filter/Doctrine/DoctrineEmptyCollectionFilter.php
@@ -4,6 +4,7 @@ namespace DeepCopy\Filter\Doctrine;
 
 use DeepCopy\Filter\Filter;
 use Doctrine\Common\Collections\ArrayCollection;
+use ReflectionProperty;
 
 class DoctrineEmptyCollectionFilter implements Filter
 {
@@ -14,9 +15,8 @@ class DoctrineEmptyCollectionFilter implements Filter
      * @param string   $property
      * @param callable $objectCopier
      */
-    public function apply($object, $property, $objectCopier)
+    public function apply($object, ReflectionProperty $reflectionProperty, $objectCopier)
     {
-        $reflectionProperty = new \ReflectionProperty($object, $property);
         $reflectionProperty->setAccessible(true);
 
         $reflectionProperty->setValue($object, new ArrayCollection());

--- a/src/DeepCopy/Filter/Filter.php
+++ b/src/DeepCopy/Filter/Filter.php
@@ -2,6 +2,8 @@
 
 namespace DeepCopy\Filter;
 
+use ReflectionProperty;
+
 /**
  * Filter to apply to a property while copying an object
  */
@@ -9,9 +11,9 @@ interface Filter
 {
     /**
      * Apply the filter to the object.
-     * @param object   $object
-     * @param string   $property
-     * @param callable $objectCopier
+     * @param object                $object
+     * @param ReflectionProperty    $reflectionProperty
+     * @param callable              $objectCopier
      */
-    public function apply($object, $property, $objectCopier);
+    public function apply($object, ReflectionProperty $reflectionProperty, $objectCopier);
 }

--- a/src/DeepCopy/Filter/KeepFilter.php
+++ b/src/DeepCopy/Filter/KeepFilter.php
@@ -2,6 +2,8 @@
 
 namespace DeepCopy\Filter;
 
+use ReflectionProperty;
+
 /**
  * Keep the value of a property
  */
@@ -10,7 +12,7 @@ class KeepFilter implements Filter
     /**
      * {@inheritdoc}
      */
-    public function apply($object, $property, $objectCopier)
+    public function apply($object, ReflectionProperty $reflectionProperty, $objectCopier)
     {
         // Nothing to do
     }

--- a/src/DeepCopy/Filter/ReplaceFilter.php
+++ b/src/DeepCopy/Filter/ReplaceFilter.php
@@ -2,6 +2,8 @@
 
 namespace DeepCopy\Filter;
 
+use ReflectionProperty;
+
 /**
  * Replace the value of a property
  */
@@ -23,9 +25,8 @@ class ReplaceFilter implements Filter
     /**
      * {@inheritdoc}
      */
-    public function apply($object, $property, $objectCopier)
+    public function apply($object, ReflectionProperty $reflectionProperty, $objectCopier)
     {
-        $reflectionProperty = new \ReflectionProperty($object, $property);
         $reflectionProperty->setAccessible(true);
 
         $value = call_user_func($this->callback, $reflectionProperty->getValue($object));

--- a/src/DeepCopy/Filter/SetNullFilter.php
+++ b/src/DeepCopy/Filter/SetNullFilter.php
@@ -12,10 +12,8 @@ class SetNullFilter implements Filter
     /**
      * {@inheritdoc}
      */
-    public function apply($object, $property, $objectCopier)
+    public function apply($object, ReflectionProperty $reflectionProperty, $objectCopier)
     {
-        $reflectionProperty = new ReflectionProperty($object, $property);
-
         $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($object, null);
     }

--- a/src/DeepCopy/Matcher/Matcher.php
+++ b/src/DeepCopy/Matcher/Matcher.php
@@ -2,6 +2,8 @@
 
 namespace DeepCopy\Matcher;
 
+use ReflectionProperty;
+
 /**
  * Matcher interface
  */
@@ -12,5 +14,5 @@ interface Matcher
      * @param string $property
      * @return boolean
      */
-    public function matches($object, $property);
+    public function matches($object, ReflectionProperty $reflectionProperty);
 }

--- a/src/DeepCopy/Matcher/PropertyMatcher.php
+++ b/src/DeepCopy/Matcher/PropertyMatcher.php
@@ -2,6 +2,8 @@
 
 namespace DeepCopy\Matcher;
 
+use ReflectionProperty;
+
 /**
  * Match a specific property of a specific class
  */
@@ -30,8 +32,8 @@ class PropertyMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function matches($object, $property)
+    public function matches($object, ReflectionProperty $reflectionProperty)
     {
-        return ($object instanceof $this->class) && ($property == $this->property);
+        return ($object instanceof $this->class) && ($reflectionProperty->getName() == $this->property);
     }
 }

--- a/src/DeepCopy/Matcher/PropertyNameMatcher.php
+++ b/src/DeepCopy/Matcher/PropertyNameMatcher.php
@@ -2,6 +2,8 @@
 
 namespace DeepCopy\Matcher;
 
+use ReflectionProperty;
+
 /**
  * Match a property by its name
  */
@@ -23,8 +25,8 @@ class PropertyNameMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function matches($object, $property)
+    public function matches($object, ReflectionProperty $reflectionProperty)
     {
-        return $property == $this->property;
+        return $reflectionProperty->getName() == $this->property;
     }
 }

--- a/src/DeepCopy/Matcher/PropertyTypeMatcher.php
+++ b/src/DeepCopy/Matcher/PropertyTypeMatcher.php
@@ -28,9 +28,8 @@ class PropertyTypeMatcher implements Matcher
     /**
      * {@inheritdoc}
      */
-    public function matches($object, $property)
+    public function matches($object, ReflectionProperty $reflectionProperty)
     {
-        $reflectionProperty = new ReflectionProperty($object, $property);
         $reflectionProperty->setAccessible(true);
 
         return $reflectionProperty->getValue($object) instanceof $this->propertyType;

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -4,7 +4,9 @@ namespace DeepCopyTest;
 
 use DeepCopy\DeepCopy;
 use DeepCopy\Filter\Filter;
+use DeepCopy\Filter\SetNullFilter;
 use DeepCopy\Matcher\PropertyMatcher;
+use DeepCopy\Matcher\PropertyTypeMatcher;
 use DeepCopy\TypeFilter\TypeFilter;
 use DeepCopy\TypeMatcher\TypeMatcher;
 
@@ -217,6 +219,24 @@ class DeepCopyTest extends AbstractTestClass
 
         $this->assertNull($new[2]);
         $this->assertNull($new[3]);
+    }
+
+    public function testPrivatePropertyOfParentObjectCopyWithFiltersAndMatchers()
+    {
+        $item = new B;
+        $item->property = 'foo';
+
+        $o = new E;
+        $o->setProperty2($item);
+
+        $deepCopy = new DeepCopy();
+        $deepCopy->addFilter(new SetNullFilter(), new PropertyTypeMatcher('DeepCopyTest\B'));
+
+        $new = $deepCopy->copy($o);
+        $newProperty2 = $new->getProperty2();
+
+        $this->assertInstanceOf('DeepCopyTest\B', $newProperty2);
+        $this->assertSame('foo', $newProperty2->property);
     }
 }
 

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -56,6 +56,21 @@ class DeepCopyTest extends AbstractTestClass
         $this->assertDeepCopyOf($o, $deepCopy->copy($o));
     }
 
+    public function testPrivatePropertyOfParentObjectCopyWithFiltersAndMatchers()
+    {
+        $o = new E();
+        $o->setProperty1(new B);
+        $o->setProperty2(new B);
+
+        $deepCopy = new DeepCopy();
+        $deepCopy->addFilter(new ReplaceFilter(function() {return 'foo';}), new PropertyTypeMatcher('DeepCopyTest\B'));
+
+        $new = $deepCopy->copy($o);
+
+        $this->assertSame('foo', $new->getProperty1());
+        $this->assertSame('foo', $new->getProperty2());
+    }
+
     public function testPropertyArrayCopy()
     {
         $o = new A();
@@ -220,19 +235,6 @@ class DeepCopyTest extends AbstractTestClass
 
         $this->assertNull($new[2]);
         $this->assertNull($new[3]);
-    }
-
-    public function testPrivatePropertyOfParentObjectCopyWithFiltersAndMatchers()
-    {
-        $o = new E;
-        $o->setProperty1(new B);
-
-        $deepCopy = new DeepCopy();
-        $deepCopy->addFilter(new ReplaceFilter(function() {return 'foo';}), new PropertyTypeMatcher('DeepCopyTest\B'));
-
-        $new = $deepCopy->copy($o);
-
-        $this->assertSame('foo', $new->getProperty1());
     }
 }
 

--- a/tests/DeepCopyTest/Filter/Doctrine/DoctrineCollectionFilterTest.php
+++ b/tests/DeepCopyTest/Filter/Doctrine/DoctrineCollectionFilterTest.php
@@ -7,6 +7,7 @@ use DeepCopy\Filter\Doctrine\DoctrineCollectionFilter;
 use DeepCopy\Matcher\PropertyMatcher;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use ReflectionProperty;
 
 /**
  * Test Doctrine Collection filter
@@ -15,19 +16,19 @@ class DoctrineCollectionFilterTest extends \PHPUnit_Framework_TestCase
 {
     public function testApply()
     {
-        $object = new \stdClass();
+        $object = new DoctrineCollectionFilterTestFixture();
         $oldCollection = new ArrayCollection();
         $oldCollection->add(new \stdClass());
-        $object->foo = $oldCollection;
+        $object->property1 = $oldCollection;
 
         $filter = new DoctrineCollectionFilter();
-        $filter->apply($object, 'foo', function($item) {
+        $filter->apply($object, new ReflectionProperty('DeepCopyTest\Filter\Doctrine\DoctrineCollectionFilterTestFixture', 'property1'), function($item) {
                 return null;
             });
 
-        $this->assertTrue($object->foo instanceof Collection);
-        $this->assertNotSame($oldCollection, $object->foo);
-        $this->assertCount(1, $object->foo);
+        $this->assertTrue($object->property1 instanceof Collection);
+        $this->assertNotSame($oldCollection, $object->property1);
+        $this->assertCount(1, $object->property1);
     }
 
     public function testIntegration()

--- a/tests/DeepCopyTest/Filter/Doctrine/DoctrineEmptyCollectionFilterTest.php
+++ b/tests/DeepCopyTest/Filter/Doctrine/DoctrineEmptyCollectionFilterTest.php
@@ -7,6 +7,7 @@ use DeepCopy\Filter\Doctrine\DoctrineEmptyCollectionFilter;
 use DeepCopy\Matcher\PropertyMatcher;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use ReflectionProperty;
 
 /**
  * Test Doctrine Collection filter
@@ -15,19 +16,19 @@ class DoctrineEmptyCollectionFilterTest extends \PHPUnit_Framework_TestCase
 {
     public function testApply()
     {
-        $object = new \StdClass();
+        $object = new DoctrineEmptyCollectionFilterTestFixture();
 
         $collection = new ArrayCollection();
         $collection->add(new \StdClass());
 
-        $object->foo = $collection;
+        $object->property1 = $collection;
 
         $filter = new DoctrineEmptyCollectionFilter();
-        $filter->apply($object, 'foo', function($item){ return null; });
+        $filter->apply($object, new ReflectionProperty('DeepCopyTest\Filter\Doctrine\DoctrineEmptyCollectionFilterTestFixture', 'property1'), function($item){ return null; });
 
-        $this->assertTrue($object->foo instanceof Collection);
-        $this->assertNotSame($collection, $object->foo);
-        $this->assertTrue($object->foo->isEmpty());
+        $this->assertTrue($object->property1 instanceof Collection);
+        $this->assertNotSame($collection, $object->property1);
+        $this->assertTrue($object->property1->isEmpty());
     }
 
     public function testIntegration()
@@ -36,16 +37,21 @@ class DoctrineEmptyCollectionFilterTest extends \PHPUnit_Framework_TestCase
         $doctrineEmptyCollectionFixture = new \StdClass();
         $originalCollection = new ArrayCollection();
         $originalCollection->add(new \StdClass());
-        $doctrineEmptyCollectionFixture->foo = $originalCollection;
+        $doctrineEmptyCollectionFixture->property1 = $originalCollection;
 
         //Copy
         $deepCopy = new DeepCopy();
-        $deepCopy->addFilter(new DoctrineEmptyCollectionFilter(), new PropertyMatcher(get_class($doctrineEmptyCollectionFixture), 'foo'));
+        $deepCopy->addFilter(new DoctrineEmptyCollectionFilter(), new PropertyMatcher(get_class($doctrineEmptyCollectionFixture), 'property1'));
         $copied = $deepCopy->copy($doctrineEmptyCollectionFixture);
 
         //Check result
-        $this->assertTrue($copied->foo instanceof Collection);
-        $this->assertNotSame($originalCollection, $copied->foo);
-        $this->assertTrue($copied->foo->isEmpty());
+        $this->assertTrue($copied->property1 instanceof Collection);
+        $this->assertNotSame($originalCollection, $copied->property1);
+        $this->assertTrue($copied->property1->isEmpty());
     }
+}
+
+class DoctrineEmptyCollectionFilterTestFixture
+{
+    public $property1;
 }

--- a/tests/DeepCopyTest/Filter/KeepFilterTest.php
+++ b/tests/DeepCopyTest/Filter/KeepFilterTest.php
@@ -5,6 +5,7 @@ namespace DeepCopyTest\Filter;
 use DeepCopy\DeepCopy;
 use DeepCopy\Filter\KeepFilter;
 use DeepCopy\Matcher\PropertyMatcher;
+use ReflectionProperty;
 
 /**
  * Test Keep filter
@@ -13,14 +14,14 @@ class KeepFilterTest extends \PHPUnit_Framework_TestCase
 {
     public function testApply()
     {
-        $object = new \stdClass();
+        $object = new KeepFilterTestFixture();
         $keepObject = new \stdClass();
-        $object->foo = $keepObject;
+        $object->property1 = $keepObject;
 
         $filter = new KeepFilter();
-        $filter->apply($object, 'foo', null);
+        $filter->apply($object, new ReflectionProperty('DeepCopyTest\Filter\KeepFilterTestFixture', 'property1'), null);
 
-        $this->assertSame($keepObject, $object->foo);
+        $this->assertSame($keepObject, $object->property1);
     }
 
     public function testIntegration()

--- a/tests/DeepCopyTest/Filter/ReplaceFilterTest.php
+++ b/tests/DeepCopyTest/Filter/ReplaceFilterTest.php
@@ -5,6 +5,7 @@ namespace DeepCopyTest\Filter;
 use DeepCopy\DeepCopy;
 use DeepCopy\Filter\ReplaceFilter;
 use DeepCopy\Matcher\PropertyMatcher;
+use ReflectionProperty;
 
 class ReplaceFilterTest extends \PHPUnit_Framework_TestCase
 {
@@ -13,16 +14,16 @@ class ReplaceFilterTest extends \PHPUnit_Framework_TestCase
      */
     public function testApply(callable $callback, array $expected)
     {
-        $object = new \stdClass();
-        $object->data = ['foo' => 'bar', 'baz' => 'foo'];
+        $object = new ReplaceFilterTestFixture();
+        $object->property1 = ['foo' => 'bar', 'baz' => 'foo'];
 
         $filter = new ReplaceFilter($callback);
 
-        $filter->apply($object, 'data', function () {
+        $filter->apply($object, new ReflectionProperty('DeepCopyTest\Filter\ReplaceFilterTestFixture', 'property1'), function () {
             return null;
         });
 
-        $this->assertEquals($expected, $object->data);
+        $this->assertEquals($expected, $object->property1);
     }
 
     public function handlerProvider()
@@ -42,8 +43,8 @@ class ReplaceFilterTest extends \PHPUnit_Framework_TestCase
     public function testIntegration()
     {
         // Prepare object to copy
-        $object = new \StdClass();
-        $object->data = [
+        $object = new ReplaceFilterTestFixture();
+        $object->property1 = [
             'foo' => 'bar',
             'baz' => ['bar' => 'foo'],
             'bar' => 'foo'
@@ -56,7 +57,7 @@ class ReplaceFilterTest extends \PHPUnit_Framework_TestCase
             unset($data['bar']);
 
             return $data;
-        }), new PropertyMatcher(get_class($object), 'data'));
+        }), new PropertyMatcher(get_class($object), 'property1'));
 
         $copied = $deepCopy->copy($object);
 
@@ -64,14 +65,19 @@ class ReplaceFilterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([
             'foo' => 'bar',
             'baz' => ['bar' => 'dummy_change']
-        ], $copied->data);
+        ], $copied->property1);
 
         // Check original object is unchanged
         $this->assertEquals(
             ['foo' => 'bar', 'baz' => ['bar' => 'foo'], 'bar' => 'foo'],
-            $object->data
+            $object->property1
         );
     }
+}
+
+class ReplaceFilterTestFixture
+{
+    public $property1;
 }
 
 class Callback

--- a/tests/DeepCopyTest/Filter/SetNullFilterTest.php
+++ b/tests/DeepCopyTest/Filter/SetNullFilterTest.php
@@ -5,6 +5,7 @@ namespace DeepCopyTest\Filter;
 use DeepCopy\DeepCopy;
 use DeepCopy\Filter\SetNullFilter;
 use DeepCopy\Matcher\PropertyMatcher;
+use ReflectionProperty;
 
 /**
  * Test SetNull filter
@@ -14,13 +15,13 @@ class SetNullFilterTest extends \PHPUnit_Framework_TestCase
     public function testApply()
     {
         $filter = new SetNullFilter();
-        $object = new \stdClass();
-        $object->foo = 'bar';
-        $object->bim = 'bam';
-        $filter->apply($object, 'foo', null);
+        $object = new SetNullFilterTestFixture();
+        $object->property1 = 'bar';
+        $object->property2 = 'bam';
+        $filter->apply($object, new ReflectionProperty('DeepCopyTest\Filter\SetNullFilterTestFixture', 'property1'), null);
 
-        $this->assertNull($object->foo);
-        $this->assertEquals('bam', $object->bim);
+        $this->assertNull($object->property1);
+        $this->assertEquals('bam', $object->property2);
     }
 
     public function testIntegration()
@@ -40,4 +41,5 @@ class SetNullFilterTest extends \PHPUnit_Framework_TestCase
 class SetNullFilterTestFixture
 {
     public $property1;
+    public $property2;
 }

--- a/tests/DeepCopyTest/Matcher/PropertyMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/PropertyMatcherTest.php
@@ -2,6 +2,7 @@
 namespace DeepCopyTest\Matcher;
 
 use DeepCopy\Matcher\PropertyMatcher;
+use ReflectionProperty;
 
 /**
  * Test PropertyMatcher
@@ -12,12 +13,14 @@ class PropertyMatcherTest extends \PHPUnit_Framework_TestCase
     {
         $matcher = new PropertyMatcher('DeepCopyTest\Matcher\PropertyMatcherTestFixture', 'property1');
 
-        $this->assertTrue($matcher->matches(new PropertyMatcherTestFixture(), 'property1'));
-        $this->assertFalse($matcher->matches(new \stdClass(), 'property1'));
-        $this->assertFalse($matcher->matches(new PropertyMatcherTestFixture(), 'property2'));
+        $this->assertTrue($matcher->matches(new PropertyMatcherTestFixture(), new ReflectionProperty('DeepCopyTest\Matcher\PropertyMatcherTestFixture', 'property1')));
+        $this->assertFalse($matcher->matches(new \stdClass(), new ReflectionProperty('DeepCopyTest\Matcher\PropertyMatcherTestFixture', 'property1')));
+        $this->assertFalse($matcher->matches(new PropertyMatcherTestFixture(), new ReflectionProperty('DeepCopyTest\Matcher\PropertyMatcherTestFixture', 'property2')));
     }
 }
 
-class PropertyMatcherTestFixture {
+class PropertyMatcherTestFixture
+{
     public $property1;
+    public $property2;
 }

--- a/tests/DeepCopyTest/Matcher/PropertyNameMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/PropertyNameMatcherTest.php
@@ -2,6 +2,7 @@
 namespace DeepCopyTest\Matcher;
 
 use DeepCopy\Matcher\PropertyNameMatcher;
+use ReflectionProperty;
 
 /**
  * Test PropertyNameMatcher
@@ -12,7 +13,13 @@ class PropertyNameMatcherTest extends \PHPUnit_Framework_TestCase
     {
         $matcher = new PropertyNameMatcher('property1');
 
-        $this->assertTrue($matcher->matches(new \stdClass(), 'property1'));
-        $this->assertFalse($matcher->matches(new \stdClass(), 'property2'));
+        $this->assertTrue($matcher->matches(new \stdClass(), new ReflectionProperty('DeepCopyTest\Matcher\PropertyNameMatcherTestFixture', 'property1')));
+        $this->assertFalse($matcher->matches(new \stdClass(), new ReflectionProperty('DeepCopyTest\Matcher\PropertyNameMatcherTestFixture', 'property2')));
     }
+}
+
+class PropertyNameMatcherTestFixture
+{
+    public $property1;
+    public $property2;
 }

--- a/tests/DeepCopyTest/Matcher/PropertyTypeMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/PropertyTypeMatcherTest.php
@@ -2,6 +2,7 @@
 namespace DeepCopyTest\Matcher;
 
 use DeepCopy\Matcher\PropertyTypeMatcher;
+use ReflectionProperty;
 
 /**
  * Test PropertyNameMatcher
@@ -13,13 +14,13 @@ class PropertyTypeMatcherTest extends \PHPUnit_Framework_TestCase
         $matcher = new PropertyTypeMatcher('DeepCopyTest\Matcher\PropertyTypeMatcherTestFixture2');
 
         $o = new PropertyTypeMatcherTestFixture1();
-        $this->assertFalse($matcher->matches($o, 'property1'));
+        $this->assertFalse($matcher->matches($o, new ReflectionProperty('DeepCopyTest\Matcher\PropertyTypeMatcherTestFixture1', 'property1')));
 
         $o->property1 = new PropertyTypeMatcherTestFixture1();
-        $this->assertFalse($matcher->matches($o, 'property1'));
+        $this->assertFalse($matcher->matches($o, new ReflectionProperty('DeepCopyTest\Matcher\PropertyTypeMatcherTestFixture1', 'property1')));
 
         $o->property1 = new PropertyTypeMatcherTestFixture2();
-        $this->assertTrue($matcher->matches($o, 'property1'));
+        $this->assertTrue($matcher->matches($o, new ReflectionProperty('DeepCopyTest\Matcher\PropertyTypeMatcherTestFixture1', 'property1')));
     }
 }
 


### PR DESCRIPTION
Currently DeepCopy does not allow to copy `private` properties on the parent class when Matchers and Filters are used, as I show in this new test: https://github.com/myclabs/DeepCopy/pull/35/files#diff-0fe594d8935dca0233edc25909b8267dR59

This is because the `ReflectionHelper` gathers all the [properties from parent classes](https://github.com/myclabs/DeepCopy/blob/1.5.0/src/DeepCopy/Reflection/ReflectionHelper.php) but the Matchers and the Filters try to instantiate their own `ReflectionProperty`, which raise an `ReflectionException` because private properties on parent class are not part of sub classes: https://3v4l.org/MuZPG

There are two solutions:
1. Use in every matcher and in every filter a new helper to find the property through the parent classes, which is backward compatible, but you have to test that everyone uses this "helper"
2. Change the Matcher and Filter interface to match the ReflectionProperty gathered be the ReflectionHelper, which is a BC break if someone is using a custom implementation of this two interfaces, but is way more solid

For this PR I chose the latter.

The current test on this subject, [testPrivatePropertyOfParentObjectCopy](https://github.com/myclabs/DeepCopy/blob/1.5.0/tests/DeepCopyTest/DeepCopyTest.php#L45-L54), passes because no matchers and no filters are used.
