### PR TITLE
stop cloning internal PHP objects.

### DIFF
--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -141,6 +141,10 @@ class DeepCopy
         $newObject = clone $object;
         $this->hashMap[$objectHash] = $newObject;
 
+        if (!$reflectedObject->isUserDefined()) {
+            return $newObject;
+        }
+
         foreach (ReflectionHelper::getProperties($reflectedObject) as $property) {
             $this->copyObjectProperty($newObject, $property);
         }

--- a/tests/DeepCopyTest/Filter/ReplaceFilterTest.php
+++ b/tests/DeepCopyTest/Filter/ReplaceFilterTest.php
@@ -42,7 +42,7 @@ class ReplaceFilterTest extends \PHPUnit_Framework_TestCase
     public function testIntegration()
     {
         // Prepare object to copy
-        $object = new \StdClass();
+        $object = new \stdClass();
         $object->data = [
             'foo' => 'bar',
             'baz' => ['bar' => 'foo'],


### PR DESCRIPTION
This fixes #38 . Internal PHP objects will no longer be cloned per property.

As far as I am aware I am not breaking anything, but would be nice if someone with more experience in reflection might be able to guarantee this.