### PR TITLE
Fix cloning of datetimes

### DIFF
--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -141,6 +141,9 @@ class DeepCopy
         $newObject = clone $object;
         $this->hashMap[$objectHash] = $newObject;
 
+        if ($newObject instanceof \DateTimeInterface) {
+            return $newObject;
+        }
         foreach (ReflectionHelper::getProperties($reflectedObject) as $property) {
             $this->copyObjectProperty($newObject, $property);
         }

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -49,8 +49,12 @@ class DeepCopyTest extends AbstractTestClass
         $o->date2 = new \DateTimeImmutable();
 
         $deepCopy = new DeepCopy();
+        $c = $deepCopy->copy($o);
 
-        $this->assertDeepCopyOf($o, $deepCopy->copy($o));
+        $this->assertDeepCopyOf($o, $c);
+
+        $c->date1->setDate(2015, 01, 04);
+        $this->assertNotEquals($c->date1, $o->date1);
     }
 
     public function testPrivatePropertyOfParentObjectCopy()

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -46,7 +46,9 @@ class DeepCopyTest extends AbstractTestClass
     {
         $o = new A();
         $o->date1 = new \DateTime();
-        $o->date2 = new \DateTimeImmutable();
+        if (class_exists('DateTimeImmutable')) {
+            $o->date2 = new \DateTimeImmutable();
+        }
 
         $deepCopy = new DeepCopy();
         $c = $deepCopy->copy($o);

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -42,6 +42,17 @@ class DeepCopyTest extends AbstractTestClass
         $this->assertDeepCopyOf($o, $deepCopy->copy($o));
     }
 
+    public function testPropertyObjectCopyWithDateTimes()
+    {
+        $o = new A();
+        $o->date1 = new \DateTime();
+        $o->date2 = new \DateTimeImmutable();
+
+        $deepCopy = new DeepCopy();
+
+        $this->assertDeepCopyOf($o, $deepCopy->copy($o));
+    }
+
     public function testPrivatePropertyOfParentObjectCopy()
     {
         $o = new E();


### PR DESCRIPTION
Fix #38 and comes as a replacement of #42. While it is possible that some cases are missed, this is an easy fix for now. IMO, as long as we don't have a clearer view on the other edge cases, it is better to try to stay simple.