### PR TITLE
Remove array_merge

### DIFF
--- a/src/DeepCopy/Reflection/ReflectionHelper.php
+++ b/src/DeepCopy/Reflection/ReflectionHelper.php
@@ -27,8 +27,8 @@ class ReflectionHelper
 
         if ($parentClass = $ref->getParentClass()) {
             $parentPropsArr = self::getProperties($parentClass);
-            if (count($parentPropsArr) > 0) {
-                $propsArr = array_merge($parentPropsArr, $propsArr);
+            foreach ($parentPropsArr as $property) {
+                $propsArr[] = $property;
             }
         }
         return $propsArr;


### PR DESCRIPTION
On the same token as #44. `array_merge` can be quite nasty as it creates a brand new array and copy the values of the two arrays being merged into it.