### PR TITLE
Use the user clone implementation when there is one

### DIFF
--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -35,6 +35,20 @@ class DeepCopy
     private $skipUncloneable = false;
 
     /**
+     * @var bool
+     */
+    private $useCloneMethod;
+
+    /**
+     * @param bool $useCloneMethod   If set to true, when an object implements the __clone() function, it will be used
+     *                               instead of the regular deep cloning.
+     */
+    public function __construct($useCloneMethod = false)
+    {
+        $this->useCloneMethod = $useCloneMethod;
+    }
+
+    /**
      * Cloning uncloneable properties won't throw exception.
      * @param $skipUncloneable
      * @return $this
@@ -140,7 +154,7 @@ class DeepCopy
 
         $newObject = clone $object;
         $this->hashMap[$objectHash] = $newObject;
-        if ($reflectedObject->hasMethod('__clone')) {
+        if ($this->useCloneMethod && $reflectedObject->hasMethod('__clone')) {
             return $object;
         }
 

--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -140,6 +140,9 @@ class DeepCopy
 
         $newObject = clone $object;
         $this->hashMap[$objectHash] = $newObject;
+        if ($reflectedObject->hasMethod('__clone')) {
+            return $object;
+        }
 
         if ($newObject instanceof \DateTimeInterface) {
             return $newObject;

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -145,12 +145,23 @@ class DeepCopyTest extends AbstractTestClass
         $deepCopy->copy($o);
     }
     
-    public function testCloneObjectsImplementing()
+    public function testCloneObjectsWithUserlandCloneMethod()
     {
         $f = new F();
         $f->prop = new \DateTime('2016-09-16');
 
         $deepCopy = new DeepCopy();
+        $newF = $deepCopy->copy($f);
+
+        $this->assertNotSame($newF->prop, $f->prop);
+    }
+
+    public function testCloneObjectsWithUserlandCloneMethodAndUseCloneableMethodEnabled()
+    {
+        $f = new F();
+        $f->prop = new \DateTime('2016-09-16');
+
+        $deepCopy = new DeepCopy(true);
         $newF = $deepCopy->copy($f);
 
         $this->assertSame($newF->prop, $f->prop);

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -144,6 +144,17 @@ class DeepCopyTest extends AbstractTestClass
         $deepCopy = new DeepCopy();
         $deepCopy->copy($o);
     }
+    
+    public function testCloneObjectsImplementing()
+    {
+        $f = new F();
+        $f->prop = new \DateTime('2016-09-16');
+
+        $deepCopy = new DeepCopy();
+        $newF = $deepCopy->copy($f);
+
+        $this->assertSame($newF->prop, $f->prop);
+    }
 
     /**
      * @test
@@ -282,5 +293,15 @@ class E extends D
     {
         $this->property2 = $property2;
         return $this;
+    }
+}
+
+class F
+{
+    public $prop;
+
+    public function __clone()
+    {
+        $this->foo = 'bar';
     }
 }


### PR DESCRIPTION
IMO if a user use the `__clone` function, it is because he has a precise idea on how the object should be cloned. For that reason, I'm inclined to think that DeepCopy should rely on that implementation instead of try to do the work on its own.

Another win is that it's potentially faster as well to rely on the user clone, so users would be able to optimize some parts if they see the need for it by implementing themselves the clone function.