### PR TITLE
Properly clone elements in Spl lists/stacks

### DIFF
--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -5,6 +5,7 @@ namespace DeepCopy;
 use DeepCopy\Exception\CloneException;
 use DeepCopy\Filter\Filter;
 use DeepCopy\Matcher\Matcher;
+use DeepCopy\TypeFilter\Spl\SplDoublyLinkedList;
 use DeepCopy\TypeFilter\TypeFilter;
 use DeepCopy\TypeMatcher\TypeMatcher;
 use ReflectionProperty;
@@ -46,6 +47,8 @@ class DeepCopy
     public function __construct($useCloneMethod = false)
     {
         $this->useCloneMethod = $useCloneMethod;
+
+        $this->addTypeFilter(new SplDoublyLinkedList($this), new TypeMatcher('\SplDoublyLinkedList'));
     }
 
     /**

--- a/src/DeepCopy/TypeFilter/Spl/SplDoublyLinkedList.php
+++ b/src/DeepCopy/TypeFilter/Spl/SplDoublyLinkedList.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace DeepCopy\TypeFilter\Spl;
+
+use DeepCopy\DeepCopy;
+use DeepCopy\TypeFilter\TypeFilter;
+
+class SplDoublyLinkedList implements TypeFilter
+{
+    /**
+     * @var DeepCopy
+     */
+    private $deepCopy;
+
+    public function __construct(DeepCopy $deepCopy)
+    {
+        $this->deepCopy = $deepCopy;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply($element)
+    {
+        $newElement = clone $element;
+
+        if ($element instanceof \SplDoublyLinkedList) {
+            // Replace each element in the list with a deep copy of itself
+            for ($i = 1; $i <= $newElement->count(); $i++) {
+                $newElement->push($this->deepCopy->copy($newElement->shift()));
+            }
+        }
+
+        return $newElement;
+
+    }
+}

--- a/tests/DeepCopyTest/AbstractTestClass.php
+++ b/tests/DeepCopyTest/AbstractTestClass.php
@@ -2,8 +2,6 @@
 
 namespace DeepCopyTest;
 
-use DeepCopy\Reflection\ReflectionHelper;
-
 /**
  * Abstract test class
  */
@@ -41,6 +39,15 @@ abstract class AbstractTestClass extends \PHPUnit_Framework_TestCase
         $this->assertSame(array_keys($expectedProperties), array_keys($actualProperties));
         foreach ($expectedProperties as $name => $value) {
             $this->assertDeepCopyOf($value, $actualProperties[$name]);
+        }
+
+        if ($expected instanceof \SplDoublyLinkedList) {
+            /** @var \SplDoublyLinkedList $actual */
+            $this->assertSame($expected->count(), $actual->count());
+
+            while (!$expected->isEmpty() && !$actual->isEmpty()) {
+                $this->assertDeepCopyOf($expected->pop(), $actual->pop());
+            }
         }
     }
 }

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -5,6 +5,9 @@ namespace DeepCopyTest;
 use DeepCopy\DeepCopy;
 use DeepCopy\Filter\Filter;
 use DeepCopy\Matcher\PropertyMatcher;
+use DeepCopy\Matcher\PropertyTypeMatcher;
+use DeepCopy\TypeFilter\Spl\SplDoublyLinkedList;
+use DeepCopy\TypeFilter\Spl\SplStackFilter;
 use DeepCopy\TypeFilter\TypeFilter;
 use DeepCopy\TypeMatcher\TypeMatcher;
 
@@ -144,7 +147,7 @@ class DeepCopyTest extends AbstractTestClass
         $deepCopy = new DeepCopy();
         $deepCopy->copy($o);
     }
-    
+
     public function testCloneObjectsWithUserlandCloneMethod()
     {
         $f = new F();
@@ -256,6 +259,24 @@ class DeepCopyTest extends AbstractTestClass
 
         $this->assertNull($new[2]);
         $this->assertNull($new[3]);
+    }
+
+    public function testSplDoublyLinkedListDeepCopy()
+    {
+        $a = new A();
+        $a->property1 = 'foo';
+        $a->property2 = new \SplDoublyLinkedList();
+
+        $b = new B();
+        $b->property = 'baz';
+        $a->property2->push($b);
+
+        $stack = new \SplDoublyLinkedList();
+        $stack->push($a);
+        $stack->push($b);
+
+        $deepCopy = new DeepCopy();
+        $this->assertDeepCopyOf($stack, $deepCopy->copy($stack));
     }
 }
 


### PR DESCRIPTION
I happened to run into this when attempting to clone an object that has an `SplStack` somewhere in its object association graph. The default behavior of `DeepCopy` creates a cloned `SplStack` such that `$stack == $clonedStack` and `$stack !== $clonedStack`, which is fine; however, the items _within_ the stack are not deep-copied... that is, `$stack->pop() === $clonedStack->pop()`.

This PR solves that issue (for `SplDoublyLinkedList`, which solves it for `SplStack` as well) by taking advantage of filters and matches. I'm not sure if adding the typefilter to the constructor is an acceptable way to do this (I generally avoid `new` in constructors myself), but I can't think of a reason why you _wouldn't_ want to properly deep-copy stacks and linked lists, given the name of this library.

I suspect data structures like SPL heaps, queues, etc... may be affected in the same way, but my immediate need is for stacks and figured I'd share what I've done to solve that.

**tl;dr:** uncomment the new line 51 of `src/DeepCopy/DeepCopy.php` and run PHPUnit. :)
