### PR TITLE
ReflectionHelper: BC break fix introduced in 1.5.3

### DIFF
--- a/src/DeepCopy/Reflection/ReflectionHelper.php
+++ b/src/DeepCopy/Reflection/ReflectionHelper.php
@@ -27,9 +27,8 @@ class ReflectionHelper
 
         if ($parentClass = $ref->getParentClass()) {
             $parentPropsArr = self::getProperties($parentClass);
-            foreach ($parentPropsArr as $property) {
-                $f = $property->getName();
-                $propsArr[$f] = $property;
+            if (count($parentPropsArr) > 0) {
+                $propsArr = array_merge($parentPropsArr, $propsArr);
             }
         }
         return $propsArr;

--- a/src/DeepCopy/Reflection/ReflectionHelper.php
+++ b/src/DeepCopy/Reflection/ReflectionHelper.php
@@ -28,7 +28,8 @@ class ReflectionHelper
         if ($parentClass = $ref->getParentClass()) {
             $parentPropsArr = self::getProperties($parentClass);
             foreach ($parentPropsArr as $property) {
-                $propsArr[] = $property;
+                $f = $property->getName();
+                $propsArr[$f] = $property;
             }
         }
         return $propsArr;

--- a/tests/DeepCopyTest/Reflection/ReflectionHelperTest.php
+++ b/tests/DeepCopyTest/Reflection/ReflectionHelperTest.php
@@ -1,0 +1,35 @@
+<?php
+namespace DeepCopyTest\Reflection;
+
+use DeepCopy\Reflection\ReflectionHelper;
+
+/**
+ * Test ReflectionHelper
+ */
+class ReflectionHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testMaintainPropertiesKey()
+    {
+        $child = new ReflectionHelperTestChild();
+        $ref = new \ReflectionClass($child);
+
+        $expectedProps = array(
+            'childAttribute',
+            'parentAttribute',
+        );
+
+        $actualProps = ReflectionHelper::getProperties($ref);
+        $actualProps = array_keys($actualProps);
+        sort($actualProps);
+
+        $this->assertSame($expectedProps, $actualProps);
+    }
+}
+
+class ReflectionHelperTestParent {
+    public $parentAttribute;
+}
+
+class ReflectionHelperTestChild extends ReflectionHelperTestParent {
+    public $childAttribute;
+}

--- a/tests/DeepCopyTest/Reflection/ReflectionHelperTest.php
+++ b/tests/DeepCopyTest/Reflection/ReflectionHelperTest.php
@@ -14,22 +14,39 @@ class ReflectionHelperTest extends \PHPUnit_Framework_TestCase
         $ref = new \ReflectionClass($child);
 
         $expectedProps = array(
-            'childAttribute',
-            'parentAttribute',
+            'a1',
+            'a2',
+            'a3',
+            'a4',
+            'a5',
+            'a6',
+            'a7',
+            'a8',
+            'a9',
         );
 
         $actualProps = ReflectionHelper::getProperties($ref);
-        $actualProps = array_keys($actualProps);
-        sort($actualProps);
 
-        $this->assertSame($expectedProps, $actualProps);
+        $this->assertSame($expectedProps, array_keys($actualProps));
     }
 }
 
 class ReflectionHelperTestParent {
-    public $parentAttribute;
+    public $a1;
+    protected $a2;
+    private $a3;
+
+    public $a4;
+    protected $a5;
+    private $a6;
 }
 
 class ReflectionHelperTestChild extends ReflectionHelperTestParent {
-    public $childAttribute;
+    public $a1;
+    protected $a2;
+    private $a3;
+
+    public $a7;
+    protected $a8;
+    private $a9;
 }


### PR DESCRIPTION
This PR reverts commit:
https://github.com/myclabs/DeepCopy/commit/c5979d6373474ed731261d3a105e347b7f995b70

`array_merge` preserves keys ([link](http://php.net/manual/en/function.array-merge.php)):
>  If the input arrays have the same string keys, then the later value for that key will overwrite the previous one. If, however, the arrays contain numeric keys, the later value will not overwrite the original value, but will be appended. 

The bugfix should be immediately merged, this is breaking every cloning of classes with parents.

If you want to get rid of the `array_merge` function, the test ensures the behaviour will remain the same.