### PR TITLE
Enhance Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,31 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
+  - '5.5'
+  - '5.6'
+  - '7.0'
+  - '7.1'
+  - nightly
   - hhvm
 
 matrix:
+  fast_finish: true
+  include:
+    - php: '5.4'
+      env: COMPOSER_FLAGS="--prefer-lowest"
   allow_failures:
+    - php: nightly
     - php: hhvm
 
+before_install:
+  - |
+    if [ "$TRAVIS_PHP_VERSION" = "nightly" ] || "$TRAVIS_PHP_VERSION" = "7.1" ]; then
+      COMPOSER_FLAGS="$COMPOSER_FLAGS --ignore-platform-reqs"
+    fi;
+
 install:
-  - composer install -n
-  - composer require "satooshi/php-coveralls:~1.0" --no-progress
+  - composer update -n --prefer-dist $COMPOSER_FLAGS
+  - wget https://github.com/satooshi/php-coveralls/releases/download/v1.0.0/coveralls.phar
 
 before_script:
   - mkdir -p build/logs
@@ -22,4 +34,4 @@ script:
   - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_script:
-  - php vendor/bin/coveralls -v
+  - php coveralls.phar -v

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "psr-4": { "DeepCopyTest\\": "tests/DeepCopyTest/" }
     },
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.4.0 <7.2"
     },
     "require-dev": {
         "doctrine/collections": "1.*",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "psr-4": { "DeepCopyTest\\": "tests/DeepCopyTest/" }
     },
     "require": {
-        "php": ">=5.4.0 <7.2"
+        "php": ">=5.4.0"
     },
     "require-dev": {
         "doctrine/collections": "1.*",


### PR DESCRIPTION
- Add tests for PHP 7.1 and nightly builds
- Add tests for minimal version (PHP 5.4 with prefer lowest)
- Bound upper PHP version
- Install coveralls PHAR instead of requiring the dep
- Install dist dependency preferably to reduce the amount of data to download