### PR TITLE
Bound PHP upper limit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "psr-4": { "DeepCopyTest\\": "tests/DeepCopyTest/" }
     },
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.4.0 <7.2"
     },
     "require-dev": {
         "doctrine/collections": "1.*",


### PR DESCRIPTION
So to follow the discussion of https://github.com/myclabs/DeepCopy/pull/53#discussion_r80131557, I would say having an upper limit is *safer*. If a support should be added when a new release is available:

- Most of the time a patch removing the constraint can easily be added
- You can force the install with `--ignore-platform-args`

IMO this experience is nicer than installing a package and then discovering it won't work because instead of failing at the installation process.