### PR TITLE
Copy origin object property value fix

### DIFF
--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -162,13 +162,13 @@ class DeepCopy
             return $newObject;
         }
         foreach (ReflectionHelper::getProperties($reflectedObject) as $property) {
-            $this->copyObjectProperty($newObject, $property);
+            $this->copyObjectProperty($object, $newObject, $property);
         }
 
         return $newObject;
     }
 
-    private function copyObjectProperty($object, ReflectionProperty $property)
+    private function copyObjectProperty($object, $newObject, ReflectionProperty $property)
     {
         // Ignore static properties
         if ($property->isStatic()) {
@@ -182,9 +182,9 @@ class DeepCopy
             /** @var Filter $filter */
             $filter = $item['filter'];
 
-            if ($matcher->matches($object, $property->getName())) {
+            if ($matcher->matches($newObject, $property->getName())) {
                 $filter->apply(
-                    $object,
+                    $newObject,
                     $property->getName(),
                     function ($object) {
                         return $this->recursiveCopy($object);
@@ -199,7 +199,7 @@ class DeepCopy
         $propertyValue = $property->getValue($object);
 
         // Copy the property
-        $property->setValue($object, $this->recursiveCopy($propertyValue));
+        $property->setValue($newObject, $this->recursiveCopy($propertyValue));
     }
 
     /**

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -171,6 +171,17 @@ class DeepCopyTest extends AbstractTestClass
         $this->assertNotSame($newF->prop, $f->prop);
     }
 
+    public function testCloneObjectsWithUserlandCloneMethodManipulateExistingPropertyValue()
+    {
+        $i = new I();
+        $i->property = 'my_value';
+
+        $deepCopy = new DeepCopy(false);
+        $newI = $deepCopy->copy($i);
+
+        $this->assertSame('my_value', $newI->property);
+    }
+
     public function testCloneObjectsWithUserlandCloneMethodAndUseCloneableMethodEnabled()
     {
         $f = new F();
@@ -340,4 +351,10 @@ class G
 class H extends G
 {
     private $prop = 'bar';
+}
+
+class I extends B {
+    public function __clone() {
+        $this->property = 'value_manipulated_by__clone()_method';
+    }
 }


### PR DESCRIPTION
If you copy an object and `$useCloneMethod` flag is `FALSE` a native php clone will be done anyway and a possible existing `__clone()` method of the object gets called. If the `__clone()` method manipulate object property values the origin values will not be (re-)applied (via `DeepCopy::copyObjectProperty()`) so the copied object is no valid copy (values changed).

This should be a non-BC fix for that misbehaviour.
