### PR TITLE
skip DateTimeZone objects

### DIFF
--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -160,8 +160,7 @@ class DeepCopy
         if ($this->useCloneMethod && $reflectedObject->hasMethod('__clone')) {
             return $object;
         }
-
-        if ($newObject instanceof \DateTimeInterface) {
+        if ($newObject instanceof \DateTimeZone || $newObject instanceof \DateTimeInterface) {
             return $newObject;
         }
         foreach (ReflectionHelper::getProperties($reflectedObject) as $property) {


### PR DESCRIPTION
Pull request #43 fixes cloning of `\DateTimeInterface` objects. However, similar issue affects `\DateTimeZone` which does not implement `\DateTimeInterface`:

`Undefined property: DateTimeZone::$timezone_type`

[class.datetimezone](http://php.net/manual/en/class.datetimezone.php)

