### PR TITLE
Naive fix #75

### DIFF
--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -161,7 +161,7 @@ class DeepCopy
             return $object;
         }
 
-        if ($newObject instanceof \DateTimeInterface) {
+        if ($newObject instanceof \DateTimeInterface || $newObject instanceof \DateInterval) {
             return $newObject;
         }
         foreach (ReflectionHelper::getProperties($reflectedObject) as $property) {


### PR DESCRIPTION
Closes #75

* Does not work when subclassesed with additional properties with pointers to other objects.
* Solution could be to change handling public properties different altogether, and if the property is public, to assign them without reflection, let me know if you would prefer that approach.