### PR TITLE
Cache DeepCopy instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,7 @@ $copier = new DeepCopy(true);
 $copy = $copier->copy($var);
 ```
 
-It is however recommended to use a difference instance of `DeepCopy` between each object copy as it relies on
-`spl_object_hash` internally. As such you may want to roll your own deep copy function:
+You may want to roll your own deep copy function:
 
 ```php
 namespace Acme;
@@ -119,7 +118,11 @@ use DeepCopy\DeepCopy;
 
 function deep_copy($var)
 {
-    $copier = new DeepCopy(true);
+    static $copier = null;
+    
+    if (null === $copier) {
+        $copier = new DeepCopy(true);
+    }
     
     return $copier->copy($var);
 }

--- a/src/DeepCopy/deep_copy.php
+++ b/src/DeepCopy/deep_copy.php
@@ -12,11 +12,7 @@ namespace DeepCopy;
  */
 function deep_copy($value, $useCloneMethod = false)
 {
-    static $copier = null;
-
-    if (null === $copier) {
-        $copier = new DeepCopy($useCloneMethod);
-    }
+    $copier = new DeepCopy($useCloneMethod);
 
     return $copier->copy($value);
 }

--- a/src/DeepCopy/deep_copy.php
+++ b/src/DeepCopy/deep_copy.php
@@ -12,5 +12,11 @@ namespace DeepCopy;
  */
 function deep_copy($value, $useCloneMethod = false)
 {
-    return (new DeepCopy($useCloneMethod))->copy($value);
+    static $copier = null;
+
+    if (null === $copier) {
+        $copier = new DeepCopy($useCloneMethod);
+    }
+
+    return $copier->copy($value);
 }

--- a/src/DeepCopy/deep_copy.php
+++ b/src/DeepCopy/deep_copy.php
@@ -12,7 +12,5 @@ namespace DeepCopy;
  */
 function deep_copy($value, $useCloneMethod = false)
 {
-    $copier = new DeepCopy($useCloneMethod);
-
-    return $copier->copy($value);
+    return (new DeepCopy($useCloneMethod))->copy($value);
 }


### PR DESCRIPTION
As we reset the object hashmap between each copy, it is not necessary to create a new instance of DeepCopy between each uses.