### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,16 @@
     "require-dev": {
         "doctrine/collections": "^1.0",
         "doctrine/common": "^2.6",
-        "phpunit/phpunit": "^4.8.35"
+        "phpunit/phpunit": "^5.7"
     },
 
     "config": {
         "sort-packages": true
+    },
+
+    "extra": {
+        "branch-alias": {
+            "dev-1.x": "1.x-dev"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "doctrine/collections": "^1.0",
         "doctrine/common": "^2.6",
-        "phpunit/phpunit": "^4.1"
+        "phpunit/phpunit": "^4.8.35"
     },
 
     "config": {

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -22,7 +22,7 @@ use DeepCopy\Matcher\PropertyNameMatcher;
 use DeepCopy\Matcher\PropertyTypeMatcher;
 use DeepCopy\TypeFilter\ShallowCopyFilter;
 use DeepCopy\TypeMatcher\TypeMatcher;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use SplDoublyLinkedList;
 use stdClass;
 use function DeepCopy\deep_copy;
@@ -30,7 +30,7 @@ use function DeepCopy\deep_copy;
 /**
  * @covers \DeepCopy\DeepCopy
  */
-class DeepCopyTest extends PHPUnit_Framework_TestCase
+class DeepCopyTest extends TestCase
 {
     /**
      * @dataProvider provideScalarValues

--- a/tests/DeepCopyTest/Filter/Doctrine/DoctrineCollectionFilterTest.php
+++ b/tests/DeepCopyTest/Filter/Doctrine/DoctrineCollectionFilterTest.php
@@ -5,13 +5,13 @@ namespace DeepCopyTest\Filter\Doctrine;
 use DeepCopy\Filter\Doctrine\DoctrineCollectionFilter;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * @covers \DeepCopy\Filter\Doctrine\DoctrineCollectionFilter
  */
-class DoctrineCollectionFilterTest extends PHPUnit_Framework_TestCase
+class DoctrineCollectionFilterTest extends TestCase
 {
     public function test_it_copies_the_object_property_array_collection()
     {

--- a/tests/DeepCopyTest/Filter/Doctrine/DoctrineEmptyCollectionFilterTest.php
+++ b/tests/DeepCopyTest/Filter/Doctrine/DoctrineEmptyCollectionFilterTest.php
@@ -5,13 +5,13 @@ namespace DeepCopyTest\Filter\Doctrine;
 use DeepCopy\Filter\Doctrine\DoctrineEmptyCollectionFilter;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * @covers \DeepCopy\Filter\Doctrine\DoctrineEmptyCollectionFilter
  */
-class DoctrineEmptyCollectionFilterTest extends PHPUnit_Framework_TestCase
+class DoctrineEmptyCollectionFilterTest extends TestCase
 {
     public function test_it_sets_the_object_property_to_an_empty_doctrine_collection()
     {

--- a/tests/DeepCopyTest/Filter/Doctrine/DoctrineProxyFilterTest.php
+++ b/tests/DeepCopyTest/Filter/Doctrine/DoctrineProxyFilterTest.php
@@ -4,12 +4,12 @@ namespace DeepCopyTest\Filter\Doctrine;
 
 use BadMethodCallException;
 use DeepCopy\Filter\Doctrine\DoctrineProxyFilter;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DeepCopy\Filter\Doctrine\DoctrineProxyFilter
  */
-class DoctrineProxyFilterTest extends PHPUnit_Framework_TestCase
+class DoctrineProxyFilterTest extends TestCase
 {
     public function test_it_loads_the_doctrine_proxy()
     {

--- a/tests/DeepCopyTest/Filter/KeepFilterTest.php
+++ b/tests/DeepCopyTest/Filter/KeepFilterTest.php
@@ -3,13 +3,13 @@
 namespace DeepCopyTest\Filter;
 
 use DeepCopy\Filter\KeepFilter;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * @covers \DeepCopy\Filter\KeepFilter
  */
-class KeepFilterTest extends PHPUnit_Framework_TestCase
+class KeepFilterTest extends TestCase
 {
     public function test_it_does_not_change_the_filtered_object_property()
     {

--- a/tests/DeepCopyTest/Filter/ReplaceFilterTest.php
+++ b/tests/DeepCopyTest/Filter/ReplaceFilterTest.php
@@ -3,13 +3,13 @@
 namespace DeepCopyTest\Filter;
 
 use DeepCopy\Filter\ReplaceFilter;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * @covers \DeepCopy\Filter\ReplaceFilter
  */
-class ReplaceFilterTest extends PHPUnit_Framework_TestCase
+class ReplaceFilterTest extends TestCase
 {
     /**
      * @dataProvider provideCallbacks

--- a/tests/DeepCopyTest/Filter/SetNullFilterTest.php
+++ b/tests/DeepCopyTest/Filter/SetNullFilterTest.php
@@ -3,13 +3,13 @@
 namespace DeepCopyTest\Filter;
 
 use DeepCopy\Filter\SetNullFilter;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * @covers \DeepCopy\Filter\SetNullFilter
  */
-class SetNullFilterTest extends PHPUnit_Framework_TestCase
+class SetNullFilterTest extends TestCase
 {
     public function test_it_sets_the_given_property_to_null()
     {

--- a/tests/DeepCopyTest/Matcher/Doctrine/DoctrineProxyMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/Doctrine/DoctrineProxyMatcherTest.php
@@ -5,13 +5,13 @@ namespace DeepCopyTest\Matcher;
 use BadMethodCallException;
 use DeepCopy\Matcher\Doctrine\DoctrineProxyMatcher;
 use Doctrine\Common\Persistence\Proxy;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * @covers \DeepCopy\Matcher\Doctrine\DoctrineProxyMatcher
  */
-class DoctrineProxyMatcherTest extends PHPUnit_Framework_TestCase
+class DoctrineProxyMatcherTest extends TestCase
 {
     /**
      * @dataProvider providePairs

--- a/tests/DeepCopyTest/Matcher/PropertyMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/PropertyMatcherTest.php
@@ -3,12 +3,12 @@
 namespace DeepCopyTest\Matcher;
 
 use DeepCopy\Matcher\PropertyMatcher;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DeepCopy\Matcher\PropertyMatcher
  */
-class PropertyMatcherTest extends PHPUnit_Framework_TestCase
+class PropertyMatcherTest extends TestCase
 {
     /**
      * @dataProvider providePairs

--- a/tests/DeepCopyTest/Matcher/PropertyNameMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/PropertyNameMatcherTest.php
@@ -3,13 +3,13 @@
 namespace DeepCopyTest\Matcher;
 
 use DeepCopy\Matcher\PropertyNameMatcher;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * @covers \DeepCopy\Matcher\PropertyNameMatcher
  */
-class PropertyNameMatcherTest extends PHPUnit_Framework_TestCase
+class PropertyNameMatcherTest extends TestCase
 {
     /**
      * @dataProvider providePairs

--- a/tests/DeepCopyTest/Matcher/PropertyTypeMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/PropertyTypeMatcherTest.php
@@ -3,13 +3,13 @@
 namespace DeepCopyTest\Matcher;
 
 use DeepCopy\Matcher\PropertyTypeMatcher;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * @covers \DeepCopy\Matcher\PropertyTypeMatcher
  */
-class PropertyTypeMatcherTest extends PHPUnit_Framework_TestCase
+class PropertyTypeMatcherTest extends TestCase
 {
     /**
      * @dataProvider providePairs

--- a/tests/DeepCopyTest/Reflection/ReflectionHelperTest.php
+++ b/tests/DeepCopyTest/Reflection/ReflectionHelperTest.php
@@ -3,14 +3,14 @@
 namespace DeepCopyTest\Reflection;
 
 use DeepCopy\Reflection\ReflectionHelper;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionProperty;
 
 /**
  * @covers \DeepCopy\Reflection\ReflectionHelper
  */
-class ReflectionHelperTest extends PHPUnit_Framework_TestCase
+class ReflectionHelperTest extends TestCase
 {
     public function test_it_retrieves_the_object_properties()
     {

--- a/tests/DeepCopyTest/TypeFilter/Date/DateIntervalFilterTest.php
+++ b/tests/DeepCopyTest/TypeFilter/Date/DateIntervalFilterTest.php
@@ -4,12 +4,12 @@ namespace DeepCopyTest\TypeFilter\Date;
 
 use DateInterval;
 use DeepCopy\TypeFilter\Date\DateIntervalFilter;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DeepCopy\TypeFilter\Date\DateIntervalFilter
  */
-class DateIntervalFilterTest extends PHPUnit_Framework_TestCase
+class DateIntervalFilterTest extends TestCase
 {
     public function test_it_deep_copies_a_DateInterval()
     {

--- a/tests/DeepCopyTest/TypeFilter/ReplaceFilterTest.php
+++ b/tests/DeepCopyTest/TypeFilter/ReplaceFilterTest.php
@@ -3,13 +3,13 @@
 namespace DeepCopyTest\TypeFilter;
 
 use DeepCopy\TypeFilter\ReplaceFilter;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * @covers \DeepCopy\TypeFilter\ReplaceFilter
  */
-class ReplaceFilterTest extends PHPUnit_Framework_TestCase
+class ReplaceFilterTest extends TestCase
 {
     public function test_it_returns_the_callback_called_with_the_given_object()
     {

--- a/tests/DeepCopyTest/TypeFilter/ShallowCopyFilterTest.php
+++ b/tests/DeepCopyTest/TypeFilter/ShallowCopyFilterTest.php
@@ -3,13 +3,13 @@
 namespace DeepCopyTest\TypeFilter;
 
 use DeepCopy\TypeFilter\ShallowCopyFilter;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * @covers \DeepCopy\TypeFilter\ShallowCopyFilter
  */
-class ShallowCopyFilterTest extends PHPUnit_Framework_TestCase
+class ShallowCopyFilterTest extends TestCase
 {
     public function test_it_shallow_copies_the_given_object()
     {

--- a/tests/DeepCopyTest/TypeFilter/Spl/SplDoublyLinkedListFilterTest.php
+++ b/tests/DeepCopyTest/TypeFilter/Spl/SplDoublyLinkedListFilterTest.php
@@ -4,14 +4,14 @@ namespace DeepCopyTest\TypeFilter\Spl;
 
 use DeepCopy\DeepCopy;
 use DeepCopy\TypeFilter\Spl\SplDoublyLinkedListFilter;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use SplDoublyLinkedList;
 use stdClass;
 
 /**
  * @covers \DeepCopy\TypeFilter\Spl\SplDoublyLinkedListFilter
  */
-class SplDoublyLinkedListFilterTest extends PHPUnit_Framework_TestCase
+class SplDoublyLinkedListFilterTest extends TestCase
 {
     public function test_it_deep_copies_a_doubly_linked_spl_list()
     {

--- a/tests/DeepCopyTest/TypeMatcher/TypeMatcherTest.php
+++ b/tests/DeepCopyTest/TypeMatcher/TypeMatcherTest.php
@@ -3,13 +3,13 @@
 namespace DeepCopyTest\TypeMatcher;
 
 use DeepCopy\TypeMatcher\TypeMatcher;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * @covers \DeepCopy\TypeMatcher\TypeMatcher
  */
-class TypeMatcherTest extends PHPUnit_Framework_TestCase
+class TypeMatcherTest extends TestCase
 {
     /**
      * @dataProvider provideElements


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1). I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.