### PR TITLE
Refactoring tests

### DIFF
--- a/tests/DeepCopyTest/Filter/Doctrine/DoctrineCollectionFilterTest.php
+++ b/tests/DeepCopyTest/Filter/Doctrine/DoctrineCollectionFilterTest.php
@@ -30,7 +30,7 @@ class DoctrineCollectionFilterTest extends TestCase
             }
         );
 
-        $this->assertTrue($object->foo instanceof Collection);
+        $this->assertInstanceOf(Collection::class, $object->foo);
         $this->assertNotSame($oldCollection, $object->foo);
         $this->assertCount(1, $object->foo);
 

--- a/tests/DeepCopyTest/Filter/Doctrine/DoctrineEmptyCollectionFilterTest.php
+++ b/tests/DeepCopyTest/Filter/Doctrine/DoctrineEmptyCollectionFilterTest.php
@@ -32,7 +32,7 @@ class DoctrineEmptyCollectionFilterTest extends TestCase
             }
         );
 
-        $this->assertTrue($object->foo instanceof Collection);
+        $this->assertInstanceOf(Collection::class, $object->foo);
         $this->assertNotSame($collection, $object->foo);
         $this->assertTrue($object->foo->isEmpty());
     }

--- a/tests/DeepCopyTest/TypeFilter/Spl/SplDoublyLinkedListFilterTest.php
+++ b/tests/DeepCopyTest/TypeFilter/Spl/SplDoublyLinkedListFilterTest.php
@@ -24,7 +24,7 @@ class SplDoublyLinkedListFilterTest extends TestCase
 
         $newList = $filter->apply($list);
 
-        $this->assertSame(1, count($newList));
+        $this->assertCount(1, $newList);
         $this->assertNotSame($foo, $newList->next());
     }
 }


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertInstanceOf` instead of `instanceof` operator.