### PR TITLE
#98 - Allow applying further filters after DoctrineProxyFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ $matcher = new TypeMatcher('Doctrine\Common\Collections\Collection');
 - `DeepCopy\Filter` applies a transformation to the object attribute matched by `DeepCopy\Matcher`
 - `DeepCopy\TypeFilter` applies a transformation to any element matched by `DeepCopy\TypeMatcher`
 
+Except a few exceptions ([`DoctrineProxyFilter`](#doctrineproxyfilter-filter)), matching a filter will stop the chain
+of filters (i.e. the next ones will not be applied).
+
 
 #### `SetNullFilter` (filter)
 
@@ -271,14 +274,18 @@ Doctrine proxy class (...\\\_\_CG\_\_\Proxy).
 You can use the `DoctrineProxyFilter` to load the actual entity behind the Doctrine proxy class.
 **Make sure, though, to put this as one of your very first filters in the filter chain so that the entity is loaded
 before other filters are applied!**
+This filter won't stop the chain of filters (i.e. the next ones may be applied).
 
 ```php
 use DeepCopy\DeepCopy;
 use DeepCopy\Filter\Doctrine\DoctrineProxyFilter;
+use DeepCopy\Filter\SetNullFilter;
 use DeepCopy\Matcher\Doctrine\DoctrineProxyMatcher;
+use DeepCopy\Matcher\PropertyNameMatcher;
 
 $copier = new DeepCopy();
 $copier->addFilter(new DoctrineProxyFilter(), new DoctrineProxyMatcher());
+$copier->addFilter(new SetNullFilter(), new PropertyNameMatcher('id'));
 
 $copy = $copier->copy($object);
 

--- a/fixtures/f009/A.php
+++ b/fixtures/f009/A.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DeepCopy\f009;
+
+use Doctrine\Common\Persistence\Proxy;
+
+class A implements Proxy
+{
+    public $foo = 1;
+
+    /**
+     * @inheritdoc
+     */
+    public function __load()
+    {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __isInitialized()
+    {
+    }
+}

--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -6,6 +6,7 @@ use DateInterval;
 use DateTimeInterface;
 use DateTimeZone;
 use DeepCopy\Exception\CloneException;
+use DeepCopy\Filter\ChainableFilter;
 use DeepCopy\Filter\Filter;
 use DeepCopy\Matcher\Matcher;
 use DeepCopy\TypeFilter\Date\DateIntervalFilter;
@@ -207,6 +208,8 @@ class DeepCopy
             return;
         }
 
+        $filterWasApplied = false;
+
         // Apply the filters
         foreach ($this->filters as $item) {
             /** @var Matcher $matcher */
@@ -223,9 +226,19 @@ class DeepCopy
                     }
                 );
 
+                $filterWasApplied = true;
+
+                if ($filter instanceof ChainableFilter) {
+                    continue;
+                }
+
                 // If a filter matches, we stop processing this property
                 return;
             }
+        }
+
+        if ($filterWasApplied) {
+            return;
         }
 
         $property->setAccessible(true);

--- a/src/DeepCopy/Filter/ChainableFilter.php
+++ b/src/DeepCopy/Filter/ChainableFilter.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DeepCopy\Filter;
+
+/**
+ * Defines a filter that will not stop the chain of filters.
+ */
+interface ChainableFilter extends Filter
+{
+}

--- a/src/DeepCopy/Filter/Doctrine/DoctrineProxyFilter.php
+++ b/src/DeepCopy/Filter/Doctrine/DoctrineProxyFilter.php
@@ -2,13 +2,13 @@
 
 namespace DeepCopy\Filter\Doctrine;
 
-use DeepCopy\Filter\Filter;
+use DeepCopy\Filter\ChainableFilter;
 use ReflectionProperty;
 
 /**
  * @final
  */
-class DoctrineProxyFilter implements Filter
+class DoctrineProxyFilter implements ChainableFilter
 {
     /**
      * Triggers the magic method __load() on a Doctrine Proxy class to load the

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -16,9 +16,12 @@ use DeepCopy\f005;
 use DeepCopy\f006;
 use DeepCopy\f007;
 use DeepCopy\f008;
+use DeepCopy\f009;
+use DeepCopy\Filter\Doctrine\DoctrineProxyFilter;
 use DeepCopy\Filter\KeepFilter;
 use DeepCopy\Filter\ReplaceFilter;
 use DeepCopy\Filter\SetNullFilter;
+use DeepCopy\Matcher\Doctrine\DoctrineProxyMatcher;
 use DeepCopy\Matcher\PropertyNameMatcher;
 use DeepCopy\Matcher\PropertyTypeMatcher;
 use DeepCopy\TypeFilter\ShallowCopyFilter;
@@ -438,6 +441,22 @@ class DeepCopyTest extends TestCase
 
         $this->assertSame('foo', $new->getAProp());
         $this->assertSame('foo', $new->getBProp());
+    }
+
+    /**
+     * @ticket https://github.com/myclabs/DeepCopy/issues/98
+     */
+    public function test_it_can_apply_two_filters()
+    {
+        $object = new f009\A();
+
+        $deepCopy = new DeepCopy();
+        $deepCopy->addFilter(new DoctrineProxyFilter(), new DoctrineProxyMatcher());
+        $deepCopy->addFilter(new SetNullFilter(), new PropertyNameMatcher('foo'));
+
+        $copy = $deepCopy->copy($object);
+
+        $this->assertNull($copy->foo);
     }
 
     private function assertEqualButNotSame($expected, $val)


### PR DESCRIPTION
Closes #98

This is a proposal for allowing applying further filters after `DoctrineProxyFilter`.
If you have a better interface name idea, I will be happy to rename it.
