### PR TITLE
Various tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,6 @@ cache:
   directories:
     - $HOME/.composer/cache/files
 
-before_install:
-  - |
-    if [ "$TRAVIS_PHP_VERSION" = "nightly" ]; then
-      COMPOSER_FLAGS="$COMPOSER_FLAGS --ignore-platform-reqs"
-    fi;
-
 install:
   - composer update --no-interaction --no-progress --no-suggest --prefer-dist $COMPOSER_FLAGS
   - wget https://github.com/satooshi/php-coveralls/releases/download/v1.0.0/coveralls.phar

--- a/composer.json
+++ b/composer.json
@@ -26,15 +26,13 @@
     "require-dev": {
         "doctrine/collections": "^1.0",
         "doctrine/common": "^2.6",
-        "phpunit/phpunit": "^6.4"
+        "phpunit/phpunit": "^7.1"
+    },
+    "replace": {
+        "myclabs/deep-copy": "self.version"
     },
 
     "config": {
         "sort-packages": true
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-1.x": "1.x-dev"
-        }
     }
 }


### PR DESCRIPTION
- No longer require the composer ignore flags: there shouldn't be an issue due to this
- Upgrade to PHPUnit 7
- Use itself for PHPUnit
- Remove the branch alias config: it is simpler to keep it for major versions only