### PR TITLE
Declare deep_copy only once

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,4 @@
+build:
+    environment:
+        variables:
+            COMPOSER_ROOT_VERSION: '1.8.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: php
 
 sudo: false
 
+env:
+  global:
+    - COMPOSER_ROOT_VERSION=1.8.0
+
 php:
   - '7.1'
   - '7.2'

--- a/src/DeepCopy/deep_copy.php
+++ b/src/DeepCopy/deep_copy.php
@@ -2,15 +2,19 @@
 
 namespace DeepCopy;
 
-/**
- * Deep copies the given value.
- *
- * @param mixed $value
- * @param bool  $useCloneMethod
- *
- * @return mixed
- */
-function deep_copy($value, $useCloneMethod = false)
-{
-    return (new DeepCopy($useCloneMethod))->copy($value);
+use function function_exists;
+
+if (false === function_exists('DeepCopy\deep_copy')) {
+    /**
+     * Deep copies the given value.
+     *
+     * @param mixed $value
+     * @param bool  $useCloneMethod
+     *
+     * @return mixed
+     */
+    function deep_copy($value, $useCloneMethod = false)
+    {
+        return (new DeepCopy($useCloneMethod))->copy($value);
+    }
 }


### PR DESCRIPTION
I don't think this is a good practice in general, but since DeepCopy is used with PHPUnit and it's relatively common to find a globally installed PHPUnit, I think this is for the best.

Closes #119