### PR TITLE
Make DeepCopy API final and immutable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
   - mkdir -p build/logs
 
 script:
-  - vendor/bin/phpstan analyse -l 7 src/ tests/ fixtures/
+  - vendor/bin/phpstan analyse -l7 -cphpstan.neon src/ tests/ fixtures/
   - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_script:

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ function deep_copy($var)
     static $copier = null;
     
     if (null === $copier) {
-        $copier = new DeepCopy(true);
+        $copier = new DeepCopy();
     }
     
     return $copier->copy($var);
@@ -124,8 +124,11 @@ function deep_copy($var)
 You can add filters to customize the copy process by adding filters:
 
 ```php
-$copier = new DeepCopy();
-$copier->addFilter($filter, $matcher);
+$copier = new DeepCopy(
+    false,
+    false,
+    [[$filter, $matcher]]
+);
 ```
 
 During the copy process, when a property is matched by a [matcher][matcher], then the [filter][filter] associated to
@@ -203,8 +206,11 @@ use DeepCopy\Filter\SetNullFilter;
 $object = MyClass::load(123);
 echo $object->id; // 123
 
-$copier = new DeepCopy();
-$copier->addFilter(new SetNullFilter(), new PropertyNameMatcher('id'));
+$copier = new DeepCopy(
+    false,
+    false,
+    [[new SetNullFilter(), new PropertyNameMatcher('id')]]
+);
 
 $copy = $copier->copy($object);
 
@@ -221,10 +227,10 @@ use DeepCopy\DeepCopy;
 use DeepCopy\Filter\KeepFilter;
 use DeepCopy\Matcher\PropertyMatcher;
 
-$copier = new DeepCopy();
-$copier->addFilter(
-    new KeepFilter(),
-    new PropertyMatcher(MyClass::class, 'category')
+$copier = new DeepCopy(
+    false,
+    false,
+    [[new KeepFilter(), new PropertyMatcher(MyClass::class, 'category')]]
 );
 
 $copy = $copier->copy($object); // $object is an instance of MyClass
@@ -242,10 +248,10 @@ use DeepCopy\Filter\Doctrine\DoctrineCollectionFilter;
 use DeepCopy\Matcher\PropertyTypeMatcher;
 use Doctrine\Common\Collections\Collection;
 
-$copier = new DeepCopy();
-$copier->addFilter(
-    new DoctrineCollectionFilter(),
-    new PropertyTypeMatcher(Collection::class)
+$copier = new DeepCopy(
+    false,
+    false,
+    [[new DoctrineCollectionFilter(), new PropertyTypeMatcher(Collection::class)]]
 );
 
 $copy = $copier->copy($object);
@@ -262,10 +268,10 @@ use DeepCopy\DeepCopy;
 use DeepCopy\Filter\Doctrine\DoctrineEmptyCollectionFilter;
 use DeepCopy\Matcher\PropertyMatcher;
 
-$copier = new DeepCopy();
-$copier->addFilter(
-    new DoctrineEmptyCollectionFilter(),
-    new PropertyMatcher(MyClass::class, 'myProperty')
+$copier = new DeepCopy(
+    false,
+    false,
+    [[new DoctrineEmptyCollectionFilter(), new PropertyMatcher(MyClass::class, 'myProperty')]]
 );
 
 $copy = $copier->copy($object);
@@ -292,9 +298,14 @@ use DeepCopy\Filter\SetNullFilter;
 use DeepCopy\Matcher\Doctrine\DoctrineProxyMatcher;
 use DeepCopy\Matcher\PropertyNameMatcher;
 
-$copier = new DeepCopy();
-$copier->addFilter(new DoctrineProxyFilter(), new DoctrineProxyMatcher());
-$copier->addFilter(new SetNullFilter(), new PropertyNameMatcher('id'));
+$copier = new DeepCopy(
+    false,
+    false,
+    [
+        [new DoctrineProxyFilter(), new DoctrineProxyMatcher()],
+        [new SetNullFilter(), new PropertyNameMatcher('id')],
+    ]
+);
 
 $copy = $copier->copy($object);
 
@@ -311,14 +322,19 @@ use DeepCopy\DeepCopy;
 use DeepCopy\Filter\ReplaceFilter;
 use DeepCopy\Matcher\PropertyMatcher;
 
-$copier = new DeepCopy();
-$copier->addFilter(
-    new ReplaceFilter(
-        function ($currentValue): string {
-            return $currentValue . ' (copy)'
-        }
-    ),
-    new PropertyMatcher(MyClass::class, 'title')
+$copier = new DeepCopy(
+    false,
+    false,
+    [
+        [
+            new ReplaceFilter(
+                 function ($currentValue): string {
+                     return $currentValue . ' (copy)'
+                 }
+            ),
+            new PropertyMatcher(MyClass::class, 'title'),
+        ],
+    ]
 );
 
 $copy = $copier->copy($object); // $object is an instance of MyClass
@@ -333,14 +349,19 @@ use DeepCopy\DeepCopy;
 use DeepCopy\TypeFilter\ReplaceFilter;
 use DeepCopy\TypeMatcher\TypeMatcher;
 
-$copier = new DeepCopy();
-$copier->addFilter(
-    new ReplaceFilter(
-        function (MyClass $myClass): string {
-            return get_class($myClass)
-        }
-    ),
-    new TypeMatcher(MyClass::class)
+$copier = new DeepCopy(
+    false,
+    false,
+    [
+        [
+            new ReplaceFilter(
+                function (MyClass $myClass): string {
+                    return get_class($myClass)
+                }
+            ),
+            new TypeMatcher(MyClass::class),
+        ],
+    ]
 );
 
 $copy = $copier->copy([new MyClass, 'some string', new MyClass]);
@@ -359,10 +380,11 @@ use DeepCopy\TypeFilter\ShallowCopyFilter;
 use DeepCopy\TypeMatcher\TypeMatcher;
 use Mockery as m;
 
-$copier = new DeepCopy();
-$copier->addTypeFilter(
-	new ShallowCopyFilter,
-	new TypeMatcher(m\MockInterface::class)
+$copier = new DeepCopy(
+    false,
+    false,
+    [],
+    [[new ShallowCopyFilter, new TypeMatcher(m\MockInterface::class)]]
 );
 
 $myServiceWithMocks = new MyService(

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+    ignoreErrors:
+        - '#PHPDoc tag \@param has invalid value \(Array\<Filter\, Matcher\>#'
+        - '#PHPDoc tag \@param has invalid value \(Array\<TypeFilter\, TypeMatcher\>#'

--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -43,9 +43,9 @@ final class DeepCopy
     private $useCloneMethod;
 
     /**
-     * @param bool $useCloneMethod If set to true, when an object implements the __clone() function, it will
+     * @param bool $useCloneMethod           If set to true, when an object implements the __clone() function, it will
      *                                       be used instead of the regular deep cloning.
-     * @param bool $skipUncloneable If enabled, will not throw an exception when coming across an uncloneable
+     * @param bool $skipUncloneable          If enabled, will not throw an exception when coming across an uncloneable
      *                                       property.
      * @param Array<Filter, Matcher>         List of filter-matcher pairs
      * @param Array<TypeFilter, TypeMatcher> List of type filter-matcher pairs
@@ -76,16 +76,6 @@ final class DeepCopy
         }
 
         $this->skipUncloneable = $skipUncloneable;
-    }
-
-    private function addFilter(Filter $filter, Matcher $matcher): void
-    {
-        $this->filters[] = [$matcher, $filter];
-    }
-
-    private function addTypeFilter(TypeFilter $filter, TypeMatcher $matcher): void
-    {
-        $this->typeFilters[] = [$matcher, $filter];
     }
 
     /**
@@ -125,22 +115,6 @@ final class DeepCopy
         }
 
         return $this->copyObject($value);
-    }
-
-    /**
-     * @return TypeFilter|null The first filter that matches variable or `null` if no such filter found
-     */
-    private function getFirstMatchedTypeFilter($value): ?TypeFilter
-    {
-        foreach ($this->typeFilters as [$matcher, $typeFilter]) {
-            /** @var TypeMatcher $matcher */
-            /** @var TypeFilter $typeFilter */
-            if ($matcher->matches($value)) {
-                return $typeFilter;
-            }
-        }
-
-        return null;
     }
 
     private function copyArray(array $array): array
@@ -233,5 +207,31 @@ final class DeepCopy
 
         // Copy the property
         $property->setValue($object, $this->recursiveCopy($propertyValue));
+    }
+
+    private function addFilter(Filter $filter, Matcher $matcher): void
+    {
+        $this->filters[] = [$matcher, $filter];
+    }
+
+    private function addTypeFilter(TypeFilter $filter, TypeMatcher $matcher): void
+    {
+        $this->typeFilters[] = [$matcher, $filter];
+    }
+
+    /**
+     * @return TypeFilter|null The first filter that matches variable or `null` if no such filter found
+     */
+    private function getFirstMatchedTypeFilter($value): ?TypeFilter
+    {
+        foreach ($this->typeFilters as [$matcher, $typeFilter]) {
+            /** @var TypeMatcher $matcher */
+            /** @var TypeFilter $typeFilter */
+            if ($matcher->matches($value)) {
+                return $typeFilter;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -40,7 +40,7 @@ final class DeepCopy
      */
     private $typeFilters = [];
 
-    private $skipUncloneable = false;
+    private $skipUncloneable;
     private $useCloneMethod;
 
     /**
@@ -53,21 +53,20 @@ final class DeepCopy
      */
     public function __construct(
         bool $useCloneMethod = false,
-        bool $skipUncloneable = true,
+        bool $skipUncloneable = false,
         array $filters = [],
         array $typeFilters = []
     ) {
         $this->useCloneMethod = $useCloneMethod;
 
-        $filters[] = [
-            new DateIntervalFilter(),
-            new TypeMatcher(DateInterval::class)
-        ];
-
         foreach ($filters as [$filter, $matcher]) {
             $this->addFilter($filter, $matcher);
         }
 
+        $typeFilters[] = [
+            new DateIntervalFilter(),
+            new TypeMatcher(DateInterval::class)
+        ];
         $typeFilters[] = [
             new SplDoublyLinkedListFilter($this),
             new TypeMatcher(SplDoublyLinkedList::class)
@@ -76,6 +75,8 @@ final class DeepCopy
         foreach ($typeFilters as [$filter, $matcher]) {
             $this->addTypeFilter($filter, $matcher);
         }
+
+        $this->skipUncloneable = $skipUncloneable;
     }
 
     /**

--- a/src/DeepCopy/Exception/CloneException.php
+++ b/src/DeepCopy/Exception/CloneException.php
@@ -6,4 +6,13 @@ use UnexpectedValueException;
 
 class CloneException extends UnexpectedValueException
 {
+    final public static function unclonableClass(string $class): self
+    {
+        return new self(
+            sprintf(
+                'The class "%s" is not cloneable.',
+                $class
+            )
+        );
+    }
 }

--- a/src/DeepCopy/deep_copy.php
+++ b/src/DeepCopy/deep_copy.php
@@ -6,9 +6,9 @@ namespace DeepCopy;
  * Deep copies the given value.
  *
  * @param mixed $value
- * @param bool $useCloneMethod If set to true, when an object implements the __clone() function, it will
+ * @param bool $useCloneMethod           If set to true, when an object implements the __clone() function, it will
  *                                       be used instead of the regular deep cloning.
- * @param bool $skipUncloneable If enabled, will not throw an exception when coming across an uncloneable
+ * @param bool $skipUncloneable          If enabled, will not throw an exception when coming across an uncloneable
  *                                       property.
  * @param Array<Filter, Matcher>         List of filter-matcher pairs
  * @param Array<TypeFilter, TypeMatcher> List of type filter-matcher pairs

--- a/src/DeepCopy/deep_copy.php
+++ b/src/DeepCopy/deep_copy.php
@@ -6,11 +6,19 @@ namespace DeepCopy;
  * Deep copies the given value.
  *
  * @param mixed $value
- * @param bool  $useCloneMethod
- *
- * @return mixed
+ * @param bool $useCloneMethod           If set to true, when an object implements the __clone() function, it will
+ *                                       be used instead of the regular deep cloning.
+ * @param bool $skipUncloneable          If enabled, will not throw an exception when coming across an uncloneable
+ *                                       property.
+ * @param Array<Filter, Matcher>         List of filter-matcher pairs
+ * @param Array<TypeFilter, TypeMatcher> List of type filter-matcher pairs
  */
-function deep_copy($value, $useCloneMethod = false)
-{
-    return (new DeepCopy($useCloneMethod))->copy($value);
+public function deep_copy(
+    $value,
+    bool $useCloneMethod = false,
+    bool $skipUncloneable = true,
+    array $filters = [],
+    array $typeFilters = []
+) {
+    return (new DeepCopy($useCloneMethod, $skipUncloneable, $filters, $typeFilters))->copy($value);
 }

--- a/src/DeepCopy/deep_copy.php
+++ b/src/DeepCopy/deep_copy.php
@@ -6,9 +6,9 @@ namespace DeepCopy;
  * Deep copies the given value.
  *
  * @param mixed $value
- * @param bool $useCloneMethod           If set to true, when an object implements the __clone() function, it will
+ * @param bool $useCloneMethod If set to true, when an object implements the __clone() function, it will
  *                                       be used instead of the regular deep cloning.
- * @param bool $skipUncloneable          If enabled, will not throw an exception when coming across an uncloneable
+ * @param bool $skipUncloneable If enabled, will not throw an exception when coming across an uncloneable
  *                                       property.
  * @param Array<Filter, Matcher>         List of filter-matcher pairs
  * @param Array<TypeFilter, TypeMatcher> List of type filter-matcher pairs
@@ -19,6 +19,7 @@ function deep_copy(
     bool $skipUncloneable = false,
     array $filters = [],
     array $typeFilters = []
-) {
+)
+{
     return (new DeepCopy($useCloneMethod, $skipUncloneable, $filters, $typeFilters))->copy($value);
 }

--- a/src/DeepCopy/deep_copy.php
+++ b/src/DeepCopy/deep_copy.php
@@ -13,10 +13,10 @@ namespace DeepCopy;
  * @param Array<Filter, Matcher>         List of filter-matcher pairs
  * @param Array<TypeFilter, TypeMatcher> List of type filter-matcher pairs
  */
-public function deep_copy(
+function deep_copy(
     $value,
     bool $useCloneMethod = false,
-    bool $skipUncloneable = true,
+    bool $skipUncloneable = false,
     array $filters = [],
     array $typeFilters = []
 ) {

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -166,10 +166,15 @@ class DeepCopyTest extends TestCase
      */
     public function test_it_skips_the_copy_for_userland_datetimezone()
     {
-        $deepCopy = new DeepCopy();
-        $deepCopy->addFilter(
-            new SetNullFilter(),
-            new PropertyNameMatcher('cloned')
+        $deepCopy = new DeepCopy(
+            false,
+            true,
+            [
+                [
+                    new SetNullFilter(),
+                    new PropertyNameMatcher('cloned')
+                ]
+            ]
         );
 
         $object = new stdClass();
@@ -186,10 +191,15 @@ class DeepCopyTest extends TestCase
      */
     public function test_it_skips_the_copy_for_userland_dateinterval()
     {
-        $deepCopy = new DeepCopy();
-        $deepCopy->addFilter(
-            new SetNullFilter(),
-            new PropertyNameMatcher('cloned')
+        $deepCopy = new DeepCopy(
+            false,
+            true,
+            [
+                [
+                    new SetNullFilter(),
+                    new PropertyNameMatcher('cloned')
+                ]
+            ]
         );
 
         $object = new stdClass();
@@ -295,8 +305,7 @@ class DeepCopyTest extends TestCase
     {
         $object = new f004\UnclonableItem();
 
-        $deepCopy = new DeepCopy();
-        $deepCopy->skipUncloneable(true);
+        $deepCopy = new DeepCopy(false, true);
 
         $copy = $deepCopy->copy($object);
 
@@ -325,10 +334,16 @@ class DeepCopyTest extends TestCase
 
     public function test_it_uses_type_filter_to_copy_objects_if_matcher_matches()
     {
-        $deepCopy = new DeepCopy();
-        $deepCopy->addTypeFilter(
-            new ShallowCopyFilter(),
-            new TypeMatcher(f006\A::class)
+        $deepCopy = new DeepCopy(
+            false,
+            false,
+            [],
+            [
+                [
+                    new ShallowCopyFilter(),
+                    new TypeMatcher(f006\A::class),
+                ]
+            ]
         );
 
         $a = new f006\A;
@@ -346,10 +361,15 @@ class DeepCopyTest extends TestCase
 
     public function test_it_uses_filters_to_copy_object_properties_if_matcher_matches()
     {
-        $deepCopy = new DeepCopy();
-        $deepCopy->addFilter(
-            new SetNullFilter(),
-            new PropertyNameMatcher('cloned')
+        $deepCopy = new DeepCopy(
+            false,
+            false,
+            [
+                [
+                    new SetNullFilter(),
+                    new PropertyNameMatcher('cloned')
+                ]
+            ]
         );
 
         $a = new f006\A;
@@ -366,14 +386,19 @@ class DeepCopyTest extends TestCase
 
     public function test_it_uses_the_first_filter_matching_for_copying_object_properties()
     {
-        $deepCopy = new DeepCopy();
-        $deepCopy->addFilter(
-            new SetNullFilter(),
-            new PropertyNameMatcher('cloned')
-        );
-        $deepCopy->addFilter(
-            new KeepFilter(),
-            new PropertyNameMatcher('cloned')
+        $deepCopy = new DeepCopy(
+            false,
+            false,
+            [
+                [
+                    new SetNullFilter(),
+                    new PropertyNameMatcher('cloned')
+                ],
+                [
+                    new KeepFilter(),
+                    new PropertyNameMatcher('cloned')
+                ]
+            ]
         );
 
         $a = new f006\A;
@@ -417,8 +442,16 @@ class DeepCopyTest extends TestCase
      */
     public function test_matchers_can_access_to_parent_private_properties()
     {
-        $deepCopy = new DeepCopy();
-        $deepCopy->addFilter(new SetNullFilter(), new PropertyTypeMatcher(stdClass::class));
+        $deepCopy = new DeepCopy(
+            false,
+            false,
+            [
+                [
+                    new SetNullFilter(),
+                    new PropertyTypeMatcher(stdClass::class),
+                ]
+            ]
+        );
 
         $object = new f008\B(new stdClass());
 
@@ -434,8 +467,16 @@ class DeepCopyTest extends TestCase
         $object->setAProp(new stdClass());
         $object->setBProp(new stdClass());
 
-        $deepCopy = new DeepCopy();
-        $deepCopy->addFilter(new ReplaceFilter(function() {return 'foo';}), new PropertyTypeMatcher(stdClass::class));
+        $deepCopy = new DeepCopy(
+            false,
+            false,
+            [
+                [
+                    new ReplaceFilter(function() {return 'foo';}),
+                    new PropertyTypeMatcher(stdClass::class),
+                ]
+            ]
+        );
 
         $new = $deepCopy->copy($object);
 
@@ -450,9 +491,20 @@ class DeepCopyTest extends TestCase
     {
         $object = new f009\A();
 
-        $deepCopy = new DeepCopy();
-        $deepCopy->addFilter(new DoctrineProxyFilter(), new DoctrineProxyMatcher());
-        $deepCopy->addFilter(new SetNullFilter(), new PropertyNameMatcher('foo'));
+        $deepCopy = new DeepCopy(
+            false,
+            false,
+            [
+                [
+                    new DoctrineProxyFilter(),
+                    new DoctrineProxyMatcher(),
+                ],
+                [
+                    new SetNullFilter(),
+                    new PropertyNameMatcher('foo'),
+                ]
+            ]
+        );
 
         $copy = $deepCopy->copy($object);
 

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -46,18 +46,6 @@ class DeepCopyTest extends TestCase
         $this->assertSame($value, $copy);
     }
 
-    public function provideScalarValues()
-    {
-        return [
-            [true],
-            ['string'],
-            [null],
-            [10],
-            [-1],
-            [.5],
-        ];
-    }
-
     public function test_it_can_copy_an_array_of_scalar_values()
     {
         $copy = deep_copy([10, 20]);
@@ -72,6 +60,12 @@ class DeepCopyTest extends TestCase
         $copy = deep_copy($object);
 
         $this->assertEqualButNotSame($object, $copy);
+    }
+
+    private function assertEqualButNotSame($expected, $val)
+    {
+        $this->assertEquals($expected, $val);
+        $this->assertNotSame($expected, $val);
     }
 
     public function test_it_can_copy_an_array_of_objects()
@@ -111,6 +105,18 @@ class DeepCopyTest extends TestCase
             },
             $this->provideScalarValues()
         );
+    }
+
+    public function provideScalarValues()
+    {
+        return [
+            [true],
+            ['string'],
+            [null],
+            [10],
+            [-1],
+            [.5],
+        ];
     }
 
     public function test_it_can_copy_an_object_with_an_object_property()
@@ -472,7 +478,9 @@ class DeepCopyTest extends TestCase
             false,
             [
                 [
-                    new ReplaceFilter(function() {return 'foo';}),
+                    new ReplaceFilter(function () {
+                        return 'foo';
+                    }),
                     new PropertyTypeMatcher(stdClass::class),
                 ]
             ]
@@ -509,11 +517,5 @@ class DeepCopyTest extends TestCase
         $copy = $deepCopy->copy($object);
 
         $this->assertNull($copy->foo);
-    }
-
-    private function assertEqualButNotSame($expected, $val)
-    {
-        $this->assertEquals($expected, $val);
-        $this->assertNotSame($expected, $val);
     }
 }

--- a/tests/DeepCopyTest/Filter/Doctrine/DoctrineCollectionFilterTest.php
+++ b/tests/DeepCopyTest/Filter/Doctrine/DoctrineCollectionFilterTest.php
@@ -16,7 +16,8 @@ class DoctrineCollectionFilterTest extends TestCase
 {
     public function test_it_copies_the_object_property_array_collection()
     {
-        $object = new class {
+        $object = new class
+        {
             public $foo;
         };
         $oldCollection = new ArrayCollection();
@@ -28,7 +29,7 @@ class DoctrineCollectionFilterTest extends TestCase
         $filter->apply(
             $object,
             new ReflectionProperty($object, 'foo'),
-            function($item) {
+            function ($item) {
                 return null;
             }
         );

--- a/tests/DeepCopyTest/Filter/Doctrine/DoctrineEmptyCollectionFilterTest.php
+++ b/tests/DeepCopyTest/Filter/Doctrine/DoctrineEmptyCollectionFilterTest.php
@@ -16,7 +16,8 @@ class DoctrineEmptyCollectionFilterTest extends TestCase
 {
     public function test_it_sets_the_object_property_to_an_empty_doctrine_collection()
     {
-        $object = new class {
+        $object = new class
+        {
             public $foo;
         };
         $collection = new ArrayCollection();
@@ -29,7 +30,7 @@ class DoctrineEmptyCollectionFilterTest extends TestCase
         $filter->apply(
             $object,
             new ReflectionProperty($object, 'foo'),
-            function($item) {
+            function ($item) {
                 return null;
             }
         );

--- a/tests/DeepCopyTest/Filter/Doctrine/DoctrineProxyFilterTest.php
+++ b/tests/DeepCopyTest/Filter/Doctrine/DoctrineProxyFilterTest.php
@@ -22,7 +22,7 @@ class DoctrineProxyFilterTest extends TestCase
         $filter->apply(
             $foo,
             new ReflectionProperty($foo, 'bar'),
-            function($item) {
+            function ($item) {
                 throw new BadMethodCallException('Did not expect to be called.');
             }
         );

--- a/tests/DeepCopyTest/Filter/KeepFilterTest.php
+++ b/tests/DeepCopyTest/Filter/KeepFilterTest.php
@@ -14,7 +14,8 @@ class KeepFilterTest extends TestCase
 {
     public function test_it_does_not_change_the_filtered_object_property()
     {
-        $object = new class {
+        $object = new class
+        {
             public $foo;
         };
         $keepObject = new stdClass();
@@ -22,7 +23,8 @@ class KeepFilterTest extends TestCase
 
         $filter = new KeepFilter();
 
-        $filter->apply($object, new ReflectionProperty($object, 'foo'), function () {});
+        $filter->apply($object, new ReflectionProperty($object, 'foo'), function () {
+        });
 
         $this->assertSame($keepObject, $object->foo);
     }

--- a/tests/DeepCopyTest/Filter/ReplaceFilterTest.php
+++ b/tests/DeepCopyTest/Filter/ReplaceFilterTest.php
@@ -16,7 +16,8 @@ class ReplaceFilterTest extends TestCase
      */
     public function test_it_applies_the_callback_to_the_specified_property(callable $callback, array $expected)
     {
-        $object = new class {
+        $object = new class
+        {
             public $data;
         };
         $object->data = [
@@ -32,7 +33,7 @@ class ReplaceFilterTest extends TestCase
             function () {
                 return null;
             }
-            );
+        );
 
         $this->assertEquals($expected, $object->data);
     }

--- a/tests/DeepCopyTest/Filter/SetNullFilterTest.php
+++ b/tests/DeepCopyTest/Filter/SetNullFilterTest.php
@@ -15,14 +15,16 @@ class SetNullFilterTest extends TestCase
     {
         $filter = new SetNullFilter();
 
-        $object = new class {
+        $object = new class
+        {
             public $foo;
             public $bim;
         };
         $object->foo = 'bar';
         $object->bim = 'bam';
 
-        $filter->apply($object, new ReflectionProperty($object, 'foo'), function () {});
+        $filter->apply($object, new ReflectionProperty($object, 'foo'), function () {
+        });
 
         $this->assertNull($object->foo);
         $this->assertEquals('bam', $object->bim);

--- a/tests/DeepCopyTest/Matcher/Doctrine/DoctrineProxyMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/Doctrine/DoctrineProxyMatcherTest.php
@@ -30,7 +30,8 @@ class DoctrineProxyMatcherTest extends TestCase
         return [
             [new FooProxy(), true],
             [
-                new class {
+                new class
+                {
                     public $foo;
                 },
                 false

--- a/tests/DeepCopyTest/Matcher/PropertyNameMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/PropertyNameMatcherTest.php
@@ -16,7 +16,8 @@ class PropertyNameMatcherTest extends TestCase
      */
     public function test_it_matches_the_given_property($prop, $expected)
     {
-        $object = new class {
+        $object = new class
+        {
             public $foo;
             public $bar;
         };

--- a/tests/DeepCopyTest/Matcher/PropertyTypeMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/PropertyTypeMatcherTest.php
@@ -41,7 +41,8 @@ class PropertyTypeMatcherTest extends TestCase
             [$object2, false],
             [$object3, false],
             [
-                new class {
+                new class
+                {
                     public $foo;
                 },
                 false

--- a/tests/DeepCopyTest/Reflection/ReflectionHelperTest.php
+++ b/tests/DeepCopyTest/Reflection/ReflectionHelperTest.php
@@ -39,23 +39,26 @@ class ReflectionHelperTest extends TestCase
 
 class ReflectionHelperTestParent
 {
+    public $a1;
+    protected $a2;
+    private $a3;
+
+    public $a10;
+    protected $a11;
+    private $a12;
+
     public static $a20;
     protected static $a21;
     private static $a22;
-    public $a1;
-    public $a10;
-    protected $a2;
-    protected $a11;
-    private $a3;
-    private $a12;
 }
 
 class ReflectionHelperTestChild extends ReflectionHelperTestParent
 {
     public $a1;
-    public $a100;
     protected $a2;
-    protected $a101;
     private $a3;
+
+    public $a100;
+    protected $a101;
     private $a102;
 }

--- a/tests/DeepCopyTest/Reflection/ReflectionHelperTest.php
+++ b/tests/DeepCopyTest/Reflection/ReflectionHelperTest.php
@@ -39,26 +39,23 @@ class ReflectionHelperTest extends TestCase
 
 class ReflectionHelperTestParent
 {
-    public $a1;
-    protected $a2;
-    private $a3;
-
-    public $a10;
-    protected $a11;
-    private $a12;
-
     public static $a20;
     protected static $a21;
     private static $a22;
+    public $a1;
+    public $a10;
+    protected $a2;
+    protected $a11;
+    private $a3;
+    private $a12;
 }
 
 class ReflectionHelperTestChild extends ReflectionHelperTestParent
 {
     public $a1;
-    protected $a2;
-    private $a3;
-
     public $a100;
+    protected $a2;
     protected $a101;
+    private $a3;
     private $a102;
 }

--- a/tests/DeepCopyTest/TypeMatcher/TypeMatcherTest.php
+++ b/tests/DeepCopyTest/TypeMatcher/TypeMatcherTest.php
@@ -6,10 +6,6 @@ use DeepCopy\TypeMatcher\TypeMatcher;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-interface IA
-{
-}
-
 /**
  * @covers \DeepCopy\TypeMatcher\TypeMatcher
  */
@@ -50,5 +46,9 @@ class Bar extends Foo
 }
 
 class A implements IA
+{
+}
+
+interface IA
 {
 }

--- a/tests/DeepCopyTest/TypeMatcher/TypeMatcherTest.php
+++ b/tests/DeepCopyTest/TypeMatcher/TypeMatcherTest.php
@@ -6,6 +6,10 @@ use DeepCopy\TypeMatcher\TypeMatcher;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+interface IA
+{
+}
+
 /**
  * @covers \DeepCopy\TypeMatcher\TypeMatcher
  */
@@ -42,10 +46,6 @@ class Foo
 }
 
 class Bar extends Foo
-{
-}
-
-interface IA
 {
 }
 


### PR DESCRIPTION
This is not so much of a big change but it ensures there is only one point of injection which is preferable IMO.

That said the value is debatable and there is also the question of it is worth to backport those changes to 1.x with deprecation messages.

Closes #68 

/cc @Slamdunk