### PR TITLE
Improve error message when using Doctrine filter and doctrine is missing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     },
 
     "require": {
-        "php": "^7.2"
+        "php": "^7.2",
+        "doctrine/collections": "^1.0",
+        "doctrine/common": "^2.6"
     },
     "require-dev": {
-        "doctrine/collections": "^1.0",
-        "doctrine/common": "^2.6",
         "phpstan/phpstan": "^0.9.2",
         "phpstan/phpstan-phpunit": "^0.9.4",
         "phpunit/phpunit": "^7.1"


### PR DESCRIPTION
Logically, doctrine filters requires doctrine dependencies all the time (dev or not) :)