### PR TITLE
Fix namespace and improve assertEquals

### DIFF
--- a/tests/DeepCopyTest/Filter/SetNullFilterTest.php
+++ b/tests/DeepCopyTest/Filter/SetNullFilterTest.php
@@ -22,6 +22,6 @@ class SetNullFilterTest extends TestCase
         $filter->apply($object, 'foo', null);
 
         $this->assertNull($object->foo);
-        $this->assertEquals('bam', $object->bim);
+        $this->assertSame('bam', $object->bim);
     }
 }

--- a/tests/DeepCopyTest/Matcher/Doctrine/DoctrineProxyMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/Doctrine/DoctrineProxyMatcherTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace DeepCopyTest\Matcher;
+namespace DeepCopyTest\Matcher\Doctrine;
 
 use BadMethodCallException;
 use DeepCopy\Matcher\Doctrine\DoctrineProxyMatcher;


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and it can make assertion values strict.
- The `tests/DeepCopyTest/Matcher/Doctrine/DoctrineProxyMatcherTest.php` class namespace should change into `DeepCopyTest\Matcher\Doctrine` because it can be compatible `PSR-4` autoloading.