### PR TITLE
Fix Travis warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-sudo: false
-
 env:
   global:
     - COMPOSER_ROOT_VERSION=1.8.0


### PR DESCRIPTION
The `sudo` key is deprecated and has no effect anymore.

Example of warning: https://travis-ci.org/github/myclabs/DeepCopy/builds/730815478/config