### PR TITLE
Add isInitialized check on PropertyTypeMatcher for PHP 7.4

### DIFF
--- a/fixtures/f009/TypedObjectProperty.php
+++ b/fixtures/f009/TypedObjectProperty.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DeepCopy\f009;
+
+class TypedObjectProperty
+{
+    public \DateTime $date;
+}

--- a/src/DeepCopy/Matcher/PropertyTypeMatcher.php
+++ b/src/DeepCopy/Matcher/PropertyTypeMatcher.php
@@ -41,6 +41,12 @@ class PropertyTypeMatcher implements Matcher
 
         $reflectionProperty->setAccessible(true);
 
+        // Uninitialized properties (for PHP >7.4)
+        if (method_exists($reflectionProperty, 'isInitialized') && !$reflectionProperty->isInitialized($object)) {
+            // null instanceof $this->propertyType
+            return false;
+        }
+
         return $reflectionProperty->getValue($object) instanceof $this->propertyType;
     }
 }

--- a/tests/DeepCopyTest/Matcher/PropertyTypeMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/PropertyTypeMatcherTest.php
@@ -2,6 +2,7 @@
 
 namespace DeepCopyTest\Matcher;
 
+use DeepCopy\f009;
 use DeepCopy\Matcher\PropertyTypeMatcher;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -21,6 +22,31 @@ class PropertyTypeMatcherTest extends TestCase
         $actual = $matcher->matches($object, 'foo');
 
         $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function test_it_ignores_uninitialized_typed_properties()
+    {
+        $object = new f009\TypedObjectProperty();
+
+        $matcher = new PropertyTypeMatcher(\DateTime::class);
+
+        $this->assertFalse($matcher->matches($object, 'date'));
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function test_it_matches_initialized_typed_properties()
+    {
+        $object = new f009\TypedObjectProperty();
+        $object->date = new \DateTime();
+
+        $matcher = new PropertyTypeMatcher(\DateTime::class);
+
+        $this->assertTrue($matcher->matches($object, 'date'));
     }
 
     public function providePairs()


### PR DESCRIPTION
This fix relates to https://github.com/myclabs/DeepCopy/issues/143

Within \DeepCopy\DeepCopy::copyObjectProperty property matching occurs before reading the value, so if a PropertyTypeMatcher is set up, the same isInitialized should be performed within that operation.