### PR TITLE
Fix: Wrong properties after DeepCopy::copy()

### DIFF
--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -194,6 +194,7 @@ class DeepCopy
         }
 
         $newObject = clone $object;
+        $objectHash = spl_object_hash($newObject);
         $this->hashMap[$objectHash] = $newObject;
 
         if ($this->useCloneMethod && $reflectedObject->hasMethod('__clone')) {


### PR DESCRIPTION
After clone the spl_object_hash is changed. If the old hash is set new by php, wrong properties are set.
See https://github.com/pimcore/pimcore/issues/7760