### PR TITLE
Keep PHP 8.1 enums as is

### DIFF
--- a/fixtures/f012/Suit.php
+++ b/fixtures/f012/Suit.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace DeepCopy\f012;
+
+enum Suit: string
+{
+    case Hearts = 'Hearts';
+    case Diamonds = 'Diamonds';
+    case Clubs = 'Clubs';
+    case Spades = 'Spades';
+}

--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -140,6 +140,11 @@ class DeepCopy
             return $var;
         }
 
+        // PHP 8.1 Enum
+        if (function_exists('enum_exists') && enum_exists($var::class)) {
+            return $var;
+        }
+
         // Object
         return $this->copyObject($var);
     }

--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -141,7 +141,7 @@ class DeepCopy
         }
 
         // Enum
-        if (PHP_VERSION_ID >= 80100 && is_object($var) && enum_exists(get_class($var))) {
+        if (PHP_VERSION_ID >= 80100 && enum_exists(get_class($var))) {
             return $var;
         }
 

--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -141,7 +141,7 @@ class DeepCopy
         }
 
         // Enum
-        if (PHP_VERSION_ID >= 80100 && enum_exists($var::class)) {
+        if (PHP_VERSION_ID >= 80100 && is_object($var) && enum_exists(get_class($var))) {
             return $var;
         }
 

--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -140,8 +140,8 @@ class DeepCopy
             return $var;
         }
 
-        // PHP 8.1 Enum
-        if (function_exists('enum_exists') && enum_exists($var::class)) {
+        // Enum
+        if (PHP_VERSION_ID >= 80100 && enum_exists($var::class)) {
             return $var;
         }
 

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -19,6 +19,7 @@ use DeepCopy\f007;
 use DeepCopy\f008;
 use DeepCopy\f009;
 use DeepCopy\f011;
+use DeepCopy\f012\Suit;
 use DeepCopy\Filter\KeepFilter;
 use DeepCopy\Filter\SetNullFilter;
 use DeepCopy\Matcher\PropertyNameMatcher;
@@ -493,6 +494,18 @@ class DeepCopyTest extends TestCase
         $copy = $deepCopy->copy($object);
 
         $this->assertFalse(isset($copy->foo));
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function test_it_keeps_enums()
+    {
+        $enum = Suit::Clubs;
+
+        $copy = (new DeepCopy())->copy($enum);
+
+        $this->assertSame($enum, $copy);
     }
 
     private function assertEqualButNotSame($expected, $val)


### PR DESCRIPTION
Without this PR, enums raise the following Exception:
```
DeepCopy\Exception\CloneException: The class "DeepCopy\f012\Suit" is not cloneable.
```
I suggest to merge https://github.com/myclabs/DeepCopy/pull/170 before this one