### PR TITLE
Allow applying further filters after DoctrineProxyFilter

### DIFF
--- a/fixtures/f013/A.php
+++ b/fixtures/f013/A.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DeepCopy\f013;
+
+use Doctrine\Persistence\Proxy;
+
+class A implements Proxy
+{
+    public $foo = 1;
+
+    /**
+     * @inheritdoc
+     */
+    public function __load()
+    {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __isInitialized()
+    {
+    }
+}

--- a/fixtures/f013/B.php
+++ b/fixtures/f013/B.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DeepCopy\f013;
+
+use Doctrine\Persistence\Proxy;
+
+class B implements Proxy
+{
+    private $foo;
+
+    /**
+     * @inheritdoc
+     */
+    public function __load()
+    {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __isInitialized()
+    {
+    }
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    public function setFoo($foo)
+    {
+        $this->foo = $foo;
+    }
+}

--- a/fixtures/f013/C.php
+++ b/fixtures/f013/C.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace DeepCopy\f013;
+
+class C
+{
+    public $foo = 1;
+
+    public function __clone()
+    {
+        $this->foo = null;
+    }
+}

--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -7,6 +7,7 @@ use DateInterval;
 use DateTimeInterface;
 use DateTimeZone;
 use DeepCopy\Exception\CloneException;
+use DeepCopy\Filter\ChainableFilter;
 use DeepCopy\Filter\Filter;
 use DeepCopy\Matcher\Matcher;
 use DeepCopy\Reflection\ReflectionHelper;
@@ -238,6 +239,10 @@ class DeepCopy
                         return $this->recursiveCopy($object);
                     }
                 );
+
+                if ($filter instanceof ChainableFilter) {
+                    continue;
+                }
 
                 // If a filter matches, we stop processing this property
                 return;

--- a/src/DeepCopy/Filter/ChainableFilter.php
+++ b/src/DeepCopy/Filter/ChainableFilter.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DeepCopy\Filter;
+
+/**
+ * Defines a decorator filter that will not stop the chain of filters.
+ */
+class ChainableFilter implements Filter
+{
+    /**
+     * @var Filter
+     */
+    protected $filter;
+
+    public function __construct(Filter $filter)
+    {
+        $this->filter = $filter;
+    }
+
+    public function apply($object, $property, $objectCopier)
+    {
+        $this->filter->apply($object, $property, $objectCopier);
+    }
+}


### PR DESCRIPTION
Backport PR #101 and #133 (based issue #98) on version 1, after discussions on #173.

I continue to think that being unable to apply 2 filters with Doctrine Proxy is a bug.
If you think it's a BC break, I can create a new DoctrineProxyFilter class and depreciate the existing class, but I'm not sure how to name it.