### PR TITLE
Migrate to  phpspec/prophecy-phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "require-dev": {
         "doctrine/collections": "^1.6.8",
         "doctrine/common": "^2.13.3 || ^3.2.2",
+        "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "require-dev": {
         "doctrine/collections": "^1.6.8",
         "doctrine/common": "^2.13.3 || ^3.2.2",
+        "phpspec/prophecy": "^1.10.3",
         "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     "require-dev": {
         "doctrine/collections": "^1.6.8",
         "doctrine/common": "^2.13.3 || ^3.2.2",
-        "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
     },
     "conflict": {

--- a/tests/DeepCopyTest/TypeFilter/Spl/ArrayObjectFilterTest.php
+++ b/tests/DeepCopyTest/TypeFilter/Spl/ArrayObjectFilterTest.php
@@ -6,7 +6,7 @@ use ArrayObject;
 use DeepCopy\DeepCopy;
 use DeepCopy\TypeFilter\Spl\ArrayObjectFilter;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use RecursiveArrayIterator;
 
 /**
@@ -16,14 +16,13 @@ use RecursiveArrayIterator;
  */
 final class ArrayObjectFilterTest extends TestCase
 {
-    use ProphecyTrait;
     /**
      * @var ArrayObjectFilter
      */
     private $arrayObjectFilter;
 
     /**
-     * @var DeepCopy|ProphecyTrait
+     * @var DeepCopy|ObjectProphecy
      */
     private $copierProphecy;
 

--- a/tests/DeepCopyTest/TypeFilter/Spl/ArrayObjectFilterTest.php
+++ b/tests/DeepCopyTest/TypeFilter/Spl/ArrayObjectFilterTest.php
@@ -6,7 +6,7 @@ use ArrayObject;
 use DeepCopy\DeepCopy;
 use DeepCopy\TypeFilter\Spl\ArrayObjectFilter;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Prophecy\ObjectProphecy;
+use Prophecy\PhpUnit\ProphecyTrait;
 use RecursiveArrayIterator;
 
 /**
@@ -16,13 +16,14 @@ use RecursiveArrayIterator;
  */
 final class ArrayObjectFilterTest extends TestCase
 {
+    use ProphecyTrait;
     /**
      * @var ArrayObjectFilter
      */
     private $arrayObjectFilter;
 
     /**
-     * @var DeepCopy|ObjectProphecy
+     * @var DeepCopy|ProphecyTrait
      */
     private $copierProphecy;
 


### PR DESCRIPTION
https://github.com/sebastianbergmann/phpunit/issues/5033 changed phpunit
to no longer depend on phpspec/prophecy. This results in the need to add
a development dependency for phpspec/prophecy. Doing so results in a
warning, since PHPUnit\Framework\TestCase::prophesize() is deprecated
and will be removed in PHPUnit 10. Let's use the trait provided by
phpspec/prophecy-phpunit instead.

* Fixes #177