### PR TITLE
Better support of complex Doctrine association graphs

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -4,7 +4,7 @@ github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, u
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username
-tidelift: "packagist/myclabs/deep-copy"
+tidelift: # Replace with a Tidelif URL
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
 liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 DeepCopy helps you create deep copies (clones) of your objects. It is designed to handle cycles in the association graph.
 
-[![Total Downloads](https://poser.pugx.org/janklan/deepcopy/downloads.svg)](https://packagist.org/packages/myclabs/deep-copy)
+[![Total Downloads](https://poser.pugx.org/janklan/deepcopy/downloads.svg)](https://packagist.org/packages/janklan/deepcopy)
 [![Integrate](https://github.com/janklan/deepcopy/actions/workflows/ci.yaml/badge.svg?branch=1.x)](https://github.com/janklan/deepcopy/actions/workflows/ci.yaml)
 
 ## Table of Contents

--- a/README.md
+++ b/README.md
@@ -379,6 +379,27 @@ $myServiceWithMocks = new MyService(m::mock(MyDependency1::class), m::mock(MyDep
 ```
 
 
+## Persisting cloned Doctrine entities
+
+If you're cloning Doctrine entities and are not automatically cascading the `persist` operation, you have two options:
+
+1. Manually traverse your cloned association and persist new entities manually
+2. Use the `DeepCopy::onObjectCopied` callback to process each cloned object at the end of its cloning process. 
+
+Here is an example of the `onObjectCopied` callback that would persist your entities. 
+
+```php
+$copier = new DeepCopy();
+
+/**
+ * @var EntityManagerInterface $entityManager
+ * @var DeepCopy $copier 
+ */
+$copier->onObjectCopied = function (object $object) use ($entityManager) {
+    $entityManager->persist($object);
+};
+```
+
 ## Edge cases
 
 The following structures cannot be deep-copied with PHP Reflection. As a result they are shallow cloned and filters are

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 DeepCopy helps you create deep copies (clones) of your objects. It is designed to handle cycles in the association graph.
 
-[![Total Downloads](https://poser.pugx.org/myclabs/deep-copy/downloads.svg)](https://packagist.org/packages/myclabs/deep-copy)
-[![Integrate](https://github.com/myclabs/DeepCopy/actions/workflows/ci.yaml/badge.svg?branch=1.x)](https://github.com/myclabs/DeepCopy/actions/workflows/ci.yaml)
+[![Total Downloads](https://poser.pugx.org/janklan/deepcopy/downloads.svg)](https://packagist.org/packages/myclabs/deep-copy)
+[![Integrate](https://github.com/janklan/deepcopy/actions/workflows/ci.yaml/badge.svg?branch=1.x)](https://github.com/janklan/deepcopy/actions/workflows/ci.yaml)
 
 ## Table of Contents
 
@@ -36,7 +36,7 @@ DeepCopy helps you create deep copies (clones) of your objects. It is designed t
 Install with Composer:
 
 ```
-composer require myclabs/deep-copy
+composer require janklan/deepcopy
 ```
 
 Use it:
@@ -422,6 +422,17 @@ Running the tests is simple:
 vendor/bin/phpunit
 ```
 
-### Support
+## Acknowledgement
 
-Get professional support via [the Tidelift Subscription](https://tidelift.com/subscription/pkg/packagist-myclabs-deep-copy?utm_source=packagist-myclabs-deep-copy&utm_medium=referral&utm_campaign=readme).
+This is a fork of https://github.com/myclabs/DeepCopy/ - a massively popular library with millions downloads, which implies
+inherent legacy issues: it needs to support old code. At some stage I needed this library more than it did and the [PR was
+too heavy](https://github.com/myclabs/DeepCopy/pull/192) for timely consideration. 
+
+I decided to fork the project with a few objectives:
+
+1. Drop older dependencies
+2. Bring the code up a bit, PHP 8.2 and up. If you need to clone complex objects using older software, please refer to https://github.com/myclabs/DeepCopy/. This will be the last significant commit made on 1.x branch in this `janklan/deepcopy`. 
+3. Add functions that were missing - namely, the ability to automatically persist the cloned objects when cloning linked Doctrine objects
+4. As a vague goal, tweaking how the filters work. The way they are split between `TypeFilter` and `(non-Type)Filter` + the fact one can be chained and the other can't, it simply didn't sit well with me.
+
+Thanks @mnapoli for all your work. 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "myclabs/deep-copy",
+    "name": "janklan/deepcopy",
     "description": "Create deep copies (clones) of your objects",
     "license": "MIT",
     "type": "library",

--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -55,6 +55,15 @@ class DeepCopy
     private $useCloneMethod;
 
     /**
+     * Custom callback executed once an object has been fully copied and all filters applied.
+     *
+     * The original purpose of this method is to be able to grab every new object and persist it if it is a Doctrine entity.
+     *
+     * @var ?\Closure(object): void
+     */
+    public ?\Closure $onObjectCopied = null;
+
+    /**
      * @param bool $useCloneMethod   If set to true, when an object implements the __clone() function, it will be used
      *                               instead of the regular deep cloning.
      */
@@ -212,6 +221,10 @@ class DeepCopy
 
         foreach (ReflectionHelper::getProperties($reflectedObject) as $property) {
             $this->copyObjectProperty($newObject, $property);
+        }
+
+        if ($this->onObjectCopied) {
+            $this->onObjectCopied->call($this, $newObject);
         }
 
         return $newObject;

--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -61,7 +61,7 @@ class DeepCopy
      *
      * @var ?\Closure(object): void
      */
-    public ?\Closure $onObjectCopied = null;
+    public $onObjectCopied;
 
     /**
      * @param bool $useCloneMethod   If set to true, when an object implements the __clone() function, it will be used

--- a/src/DeepCopy/Filter/Doctrine/DoctrineCollectionFilter.php
+++ b/src/DeepCopy/Filter/Doctrine/DoctrineCollectionFilter.php
@@ -10,11 +10,15 @@ use DeepCopy\Reflection\ReflectionHelper;
  */
 class DoctrineCollectionFilter implements Filter
 {
+    /** @var array<class-string> */
+    private $ignoreClasses = [];
+
     /**
      * @param array<class-string> $ignoreClasses List of classes that should not be copied over to the new collection
      */
-    public function __construct(private readonly array $ignoreClasses = [])
+    public function __construct($ignoreClasses = [])
     {
+        $this->ignoreClasses = $ignoreClasses;
     }
 
     /**

--- a/tests/DeepCopyTest/Filter/Doctrine/DoctrineCollectionFilterTest.php
+++ b/tests/DeepCopyTest/Filter/Doctrine/DoctrineCollectionFilterTest.php
@@ -38,4 +38,34 @@ class DoctrineCollectionFilterTest extends TestCase
 
         $this->assertNotSame($stdClass, $objectOfNewCollection);
     }
+
+    public function test_it_ignores_objects_of_classes_when_instructed()
+    {
+        $object = new stdClass();
+        $oldCollection = new ArrayCollection();
+        $oldCollection->add($stdClass = new stdClass());
+        $oldCollection->add(new \DateTimeImmutable()); // should not be copied to the new collection
+        $oldCollection->add(new \DateTime()); // should not be copied to the new collection
+        $object->foo = $oldCollection;
+
+        $this->assertCount(3, $object->foo);
+
+        $filter = new DoctrineCollectionFilter([\DateTimeInterface::class]); // <-- here is why
+
+        $filter->apply(
+            $object,
+            'foo',
+            function($item) {
+                return null;
+            }
+        );
+
+        $this->assertInstanceOf(Collection::class, $object->foo);
+        $this->assertNotSame($oldCollection, $object->foo);
+        $this->assertCount(1, $object->foo);
+
+        $objectOfNewCollection = $object->foo->get(0);
+
+        $this->assertNotSame($stdClass, $objectOfNewCollection);
+    }
 }


### PR DESCRIPTION
I tried to use this library to copy a subset of an association graph, where I wanted to ignore some entities completely. 

The main obstacles I faced was:

1. Persisting the cloned entities can't be achieved with the current way Filters are working
2. Our app has a number of associations along the line of "Organisation -> User[]", "Organisation -> User Group[]" and "User Group -> User[]". While there is a filter that allows to clearing a specific property, it's impractical: I'd have to explicitly list all User[] collections to be cleared (`Organisation::$users` and `UserGroup::$members`)

I figured a good way to address the first problem was to add a callback that would simply be executed at the end of the copying process. 

The second problem has a combination of use of `ReplaceFilter` that would set any `x::$user` association to null, and a modest extension to the `DoctrineCollectionFilter`, allowing to give it a list of classes that should NOT be copied over. 

This means that using the two filters together will prevent any `User` from being copied to the new set of objects:

```
$copier->addTypeFilter(new TypeFilter\ReplaceFilter(fn () => null), new TypeMatcher(User::class));
$copier->addFilter(new Filter\Doctrine\DoctrineCollectionFilter([User::class]), new Matcher\PropertyTypeMatcher(Collection::class));
```

Doing the above effectively stops the graph traversal when a "blacklisted" entity is found, regardless of whether it's located at the owning side (the TypeFilter kicks in) or the inverse side (the DoctrineCollectionFilter does). 

As a side note: If the `recursiveCopy()` wasn't private, I could just extend DeepCopy and override it so that it would also persist whatever is returned from the parent method. That's sadly not the case, hence the callable. 

I'm curious if this was an upgrade others might be interested in. If not, that's OK. I'm happy to just fork the package and keep using that fork.

--

For the record, I have been fighting errors caused by the `DeepCopy::recursiveCopy` attempting to set an ArrayCollection into a property that was not a collection (it was a `Project` entity in my case). I worked out it was because the SPL ID of the object copied was used as the index of the `DeepCopy::$hashMap` field holding said ArrayCollection, and when `DeepCopy::copyObject` was told to copy the `Project` entity, it found the SPL ID in the hash map and returned what was stored under that ID - which was the ArrayCollection:

![image](https://github.com/myclabs/DeepCopy/assets/5463371/0528267e-2e08-4270-bca7-1ea54b0c061c)

I spent a day and a half trying to figure out what the problem was and still don't know what the internal logic was causing it, but adding my filters and getting the order of filters right solved the symptoms of the problem. 

What I observed was likely reported in #180, but that issue's description isn't particularly informative. 
