### PR TITLE
feat: drop support for PHP < 8.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,11 +57,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
-          - "7.2"
-          - "7.3"
-          - "7.4"
-          - "8.0"
           - "8.1"
         dependencies:
           - "lowest"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ DeepCopy helps you create deep copies (clones) of your objects. It is designed t
 
 Install with Composer:
 
-```
+```bash
 composer require myclabs/deep-copy
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,14 @@
         "object graph"
     ],
     "require": {
-        "php": "^7.1 || ^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
-        "doctrine/collections": "^1.6.8",
-        "doctrine/common": "^2.13.3 || ^3.2.2",
-        "phpspec/prophecy": "^1.10",
-        "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+        "doctrine/collections": "^1.8 || ^2.1.4",
+        "doctrine/common": "^2.13.3 || ^3.4.3",
+        "phpspec/prophecy": "^1.18",
+        "phpspec/prophecy-phpunit": "^2.1",
+        "phpunit/phpunit": "^10.5.10"
     },
     "conflict": {
         "doctrine/collections": "<1.6.8",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,18 +4,18 @@
          colors="true">
 
     <testsuites>
-        <testsuite name="Test suite">
-            <directory>./tests/DeepCopyTest</directory>
-        </testsuite>
-    </testsuites>
+    <testsuite name="Test suite">
+      <directory>./tests/DeepCopyTest</directory>
+    </testsuite>
+  </testsuites>
 
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src/</directory>
-            <exclude>
-                <file>src/DeepCopy/deep_copy.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
+  <source>
+    <include>
+      <directory>./src/</directory>
+    </include>
+    <exclude>
+      <file>src/DeepCopy/deep_copy.php</file>
+    </exclude>
+  </source>
 
 </phpunit>

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -30,6 +30,7 @@ use DeepCopy\Matcher\PropertyNameMatcher;
 use DeepCopy\Matcher\PropertyTypeMatcher;
 use DeepCopy\TypeFilter\ShallowCopyFilter;
 use DeepCopy\TypeMatcher\TypeMatcher;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RecursiveArrayIterator;
 use SplDoublyLinkedList;
@@ -41,9 +42,7 @@ use function DeepCopy\deep_copy;
  */
 class DeepCopyTest extends TestCase
 {
-    /**
-     * @dataProvider provideScalarValues
-     */
+    #[DataProvider('provideScalarValues')]
     public function test_it_can_copy_scalar_values($value)
     {
         $copy = deep_copy($value);
@@ -51,7 +50,7 @@ class DeepCopyTest extends TestCase
         $this->assertSame($value, $copy);
     }
 
-    public function provideScalarValues()
+    public static function provideScalarValues(): array
     {
         return [
             [true],
@@ -89,9 +88,7 @@ class DeepCopyTest extends TestCase
         $this->assertEqualButNotSame($object[0], $copy[0]);
     }
 
-    /**
-     * @dataProvider provideObjectWithScalarValues
-     */
+    #[DataProvider('provideObjectWithScalarValues')]
     public function test_it_can_copy_an_object_with_scalar_properties($object, $expectedVal)
     {
         $copy = deep_copy($object);
@@ -100,7 +97,7 @@ class DeepCopyTest extends TestCase
         $this->assertSame($expectedVal, $copy->prop);
     }
 
-    public function provideObjectWithScalarValues()
+    public function provideObjectWithScalarValues(): array
     {
         $createObject = function ($val) {
             $object = new stdClass();

--- a/tests/DeepCopyTest/Filter/ReplaceFilterTest.php
+++ b/tests/DeepCopyTest/Filter/ReplaceFilterTest.php
@@ -3,6 +3,7 @@
 namespace DeepCopyTest\Filter;
 
 use DeepCopy\Filter\ReplaceFilter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -11,9 +12,7 @@ use stdClass;
  */
 class ReplaceFilterTest extends TestCase
 {
-    /**
-     * @dataProvider provideCallbacks
-     */
+    #[DataProvider('provideCallbacks')]
     public function test_it_applies_the_callback_to_the_specified_property(callable $callback, array $expected)
     {
         $object = new stdClass();
@@ -35,7 +34,7 @@ class ReplaceFilterTest extends TestCase
         $this->assertEquals($expected, $object->data);
     }
 
-    public function provideCallbacks()
+    public static function provideCallbacks(): array
     {
         return [
             [

--- a/tests/DeepCopyTest/Matcher/Doctrine/DoctrineProxyMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/Doctrine/DoctrineProxyMatcherTest.php
@@ -5,6 +5,7 @@ namespace DeepCopyTest\Matcher\Doctrine;
 use BadMethodCallException;
 use DeepCopy\Matcher\Doctrine\DoctrineProxyMatcher;
 use Doctrine\Persistence\Proxy;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -13,9 +14,7 @@ use stdClass;
  */
 class DoctrineProxyMatcherTest extends TestCase
 {
-    /**
-     * @dataProvider providePairs
-     */
+    #[DataProvider('providePairs')]
     public function test_it_matches_the_given_objects($object, $expected)
     {
         $matcher = new DoctrineProxyMatcher();
@@ -25,7 +24,7 @@ class DoctrineProxyMatcherTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function providePairs()
+    public static function providePairs(): array
     {
         return [
             [new FooProxy(), true],

--- a/tests/DeepCopyTest/Matcher/PropertyMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/PropertyMatcherTest.php
@@ -3,6 +3,7 @@
 namespace DeepCopyTest\Matcher;
 
 use DeepCopy\Matcher\PropertyMatcher;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -10,9 +11,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PropertyMatcherTest extends TestCase
 {
-    /**
-     * @dataProvider providePairs
-     */
+    #[DataProvider('providePairs')]
     public function test_it_matches_the_given_objects($object, $prop, $expected)
     {
         $matcher = new PropertyMatcher(X::class, 'foo');
@@ -22,7 +21,7 @@ class PropertyMatcherTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function providePairs()
+    public static function providePairs()
     {
         return [
             'matching case' => [new X(), 'foo', true],

--- a/tests/DeepCopyTest/Matcher/PropertyNameMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/PropertyNameMatcherTest.php
@@ -3,6 +3,7 @@
 namespace DeepCopyTest\Matcher;
 
 use DeepCopy\Matcher\PropertyNameMatcher;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -11,9 +12,7 @@ use stdClass;
  */
 class PropertyNameMatcherTest extends TestCase
 {
-    /**
-     * @dataProvider providePairs
-     */
+    #[DataProvider('providePairs')]
     public function test_it_matches_the_given_property($object, $prop, $expected)
     {
         $matcher = new PropertyNameMatcher('foo');
@@ -23,7 +22,7 @@ class PropertyNameMatcherTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function providePairs()
+    public static function providePairs(): array
     {
         return [
             [new stdClass(), 'foo', true],

--- a/tests/DeepCopyTest/Matcher/PropertyTypeMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/PropertyTypeMatcherTest.php
@@ -4,6 +4,7 @@ namespace DeepCopyTest\Matcher;
 
 use DeepCopy\f009;
 use DeepCopy\Matcher\PropertyTypeMatcher;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -12,9 +13,7 @@ use stdClass;
  */
 class PropertyTypeMatcherTest extends TestCase
 {
-    /**
-     * @dataProvider providePairs
-     */
+    #[DataProvider('providePairs')]
     public function test_it_matches_the_given_property($object, $expected)
     {
         $matcher = new PropertyTypeMatcher(PropertyTypeMatcherTestFixture2::class);
@@ -49,7 +48,7 @@ class PropertyTypeMatcherTest extends TestCase
         $this->assertTrue($matcher->matches($object, 'date'));
     }
 
-    public function providePairs()
+    public static function providePairs(): array
     {
         $object1 = new PropertyTypeMatcherTestFixture1();
         $object1->foo = new PropertyTypeMatcherTestFixture2();

--- a/tests/DeepCopyTest/Reflection/ReflectionHelperTest.php
+++ b/tests/DeepCopyTest/Reflection/ReflectionHelperTest.php
@@ -4,6 +4,7 @@ namespace DeepCopyTest\Reflection;
 
 use DeepCopy\Exception\PropertyException;
 use DeepCopy\Reflection\ReflectionHelper;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionProperty;
@@ -38,9 +39,7 @@ class ReflectionHelperTest extends TestCase
         $this->assertSame($expectedProps, array_keys($actualProps));
     }
 
-    /**
-     * @dataProvider provideProperties
-     */
+    #[DataProvider('provideProperties')]
     public function test_it_can_retrieve_an_object_property($name)
     {
         $object = new ReflectionHelperTestChild();
@@ -52,7 +51,7 @@ class ReflectionHelperTest extends TestCase
         $this->assertSame($name, $property->getName());
     }
 
-    public function provideProperties()
+    public static function provideProperties(): array
     {
         return [
             'public property' => ['a10'],

--- a/tests/DeepCopyTest/TypeFilter/Spl/ArrayObjectFilterTest.php
+++ b/tests/DeepCopyTest/TypeFilter/Spl/ArrayObjectFilterTest.php
@@ -6,6 +6,7 @@ use ArrayObject;
 use DeepCopy\DeepCopy;
 use DeepCopy\TypeFilter\Spl\ArrayObjectFilter;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use RecursiveArrayIterator;
 
@@ -16,15 +17,11 @@ use RecursiveArrayIterator;
  */
 final class ArrayObjectFilterTest extends TestCase
 {
-    /**
-     * @var ArrayObjectFilter
-     */
-    private $arrayObjectFilter;
+    use ProphecyTrait;
 
-    /**
-     * @var DeepCopy|ObjectProphecy
-     */
-    private $copierProphecy;
+    private ArrayObjectFilter $arrayObjectFilter;
+
+    private ObjectProphecy|DeepCopy $copierProphecy;
 
     protected function setUp(): void
     {

--- a/tests/DeepCopyTest/TypeFilter/Spl/SplDoublyLinkedListFilterTest.php
+++ b/tests/DeepCopyTest/TypeFilter/Spl/SplDoublyLinkedListFilterTest.php
@@ -34,7 +34,7 @@ class FakeDeepCopy extends DeepCopy
     /**
      * @inheritdoc
      */
-    public function copy($object)
+    public function copy(mixed $object)
     {
         return new stdClass();
     }

--- a/tests/DeepCopyTest/TypeMatcher/TypeMatcherTest.php
+++ b/tests/DeepCopyTest/TypeMatcher/TypeMatcherTest.php
@@ -3,6 +3,7 @@
 namespace DeepCopyTest\TypeMatcher;
 
 use DeepCopy\TypeMatcher\TypeMatcher;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -11,9 +12,7 @@ use stdClass;
  */
 class TypeMatcherTest extends TestCase
 {
-    /**
-     * @dataProvider provideElements
-     */
+    #[DataProvider('provideElements')]
     public function test_it_retrieves_the_object_properties($type, $element, $expected)
     {
         $matcher = new TypeMatcher($type);
@@ -23,7 +22,7 @@ class TypeMatcherTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function provideElements()
+    public static function provideElements(): array
     {
         return [
             '[class] same class as type' => ['stdClass', new stdClass(), true],


### PR DESCRIPTION
migrate to PHPUnit 10

Usage statistics: https://packagist.org/packages/myclabs/deep-copy/php-stats

There are no changes in src/
These are up to follow up PRs

https://github.com/myclabs/DeepCopy/pull/193 should be merged upfront