### PR TITLE
bug: #196 Introduce a custom DatePeriodFilter that safely copies DatePeriod objects without modifying their readonly properties.

### DIFF
--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -4,6 +4,7 @@ namespace DeepCopy;
 
 use ArrayObject;
 use DateInterval;
+use DatePeriod;
 use DateTimeInterface;
 use DateTimeZone;
 use DeepCopy\Exception\CloneException;
@@ -12,6 +13,7 @@ use DeepCopy\Filter\Filter;
 use DeepCopy\Matcher\Matcher;
 use DeepCopy\Reflection\ReflectionHelper;
 use DeepCopy\TypeFilter\Date\DateIntervalFilter;
+use DeepCopy\TypeFilter\Date\DatePeriodFilter;
 use DeepCopy\TypeFilter\Spl\ArrayObjectFilter;
 use DeepCopy\TypeFilter\Spl\SplDoublyLinkedListFilter;
 use DeepCopy\TypeFilter\TypeFilter;
@@ -64,6 +66,7 @@ class DeepCopy
 
         $this->addTypeFilter(new ArrayObjectFilter($this), new TypeMatcher(ArrayObject::class));
         $this->addTypeFilter(new DateIntervalFilter(), new TypeMatcher(DateInterval::class));
+        $this->addTypeFilter(new DatePeriodFilter(), new TypeMatcher(DatePeriod::class));
         $this->addTypeFilter(new SplDoublyLinkedListFilter($this), new TypeMatcher(SplDoublyLinkedList::class));
     }
 

--- a/src/DeepCopy/TypeFilter/Date/DatePeriodFilter.php
+++ b/src/DeepCopy/TypeFilter/Date/DatePeriodFilter.php
@@ -31,6 +31,12 @@ class DatePeriodFilter implements TypeFilter
             return new DatePeriod($element->getStartDate(), $element->getDateInterval(), $element->getEndDate(), $options);
         }
 
-        return new DatePeriod($element->getStartDate(), $element->getDateInterval(), $element->getRecurrences(), $options);
+        if (PHP_VERSION_ID >= 70217) {
+            $recurrences = $element->getRecurrences();
+        } else {
+            $recurrences = $element->recurrences - $element->include_start_date;
+        }
+
+        return new DatePeriod($element->getStartDate(), $element->getDateInterval(), $recurrences, $options);
     }
 }

--- a/src/DeepCopy/TypeFilter/Date/DatePeriodFilter.php
+++ b/src/DeepCopy/TypeFilter/Date/DatePeriodFilter.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace DeepCopy\TypeFilter\Date;
+
+use DatePeriod;
+use DeepCopy\TypeFilter\TypeFilter;
+
+/**
+ * @final
+ */
+class DatePeriodFilter implements TypeFilter
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @param DatePeriod $element
+     *
+     * @see http://news.php.net/php.bugs/205076
+     */
+    public function apply($element)
+    {
+        $options = 0;
+        if (PHP_VERSION_ID >= 80200 && $element->include_end_date) {
+            $options |= DatePeriod::INCLUDE_END_DATE;
+        }
+        if (!$element->include_start_date) {
+            $options |= DatePeriod::EXCLUDE_START_DATE;
+        }
+
+        if ($element->getEndDate()) {
+            return new DatePeriod($element->getStartDate(), $element->getDateInterval(), $element->getEndDate(), $options);
+        }
+
+        return new DatePeriod($element->getStartDate(), $element->getDateInterval(), $element->getRecurrences(), $options);
+    }
+}

--- a/tests/DeepCopyTest/DeepCopyTest.php
+++ b/tests/DeepCopyTest/DeepCopyTest.php
@@ -4,6 +4,7 @@ namespace DeepCopyTest;
 
 use ArrayObject;
 use DateInterval;
+use DatePeriod;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
@@ -158,6 +159,7 @@ class DeepCopyTest extends TestCase
         $object->d2 = new DateTimeImmutable();
         $object->dtz = new DateTimeZone('UTC');
         $object->di = new DateInterval('P2D');
+        $object->dp = new DatePeriod(new DateTime(), new DateInterval('P2D'), 3);
 
         $copy = deep_copy($object);
 
@@ -165,6 +167,7 @@ class DeepCopyTest extends TestCase
         $this->assertEqualButNotSame($object->d2, $copy->d2);
         $this->assertEqualButNotSame($object->dtz, $copy->dtz);
         $this->assertEqualButNotSame($object->di, $copy->di);
+        $this->assertEqualButNotSame($object->dp, $copy->dp);
     }
 
     /**

--- a/tests/DeepCopyTest/TypeFilter/Date/DatePeriodFilterTest.php
+++ b/tests/DeepCopyTest/TypeFilter/Date/DatePeriodFilterTest.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace DeepCopyTest\TypeFilter\Date;
+
+use DateInterval;
+use DatePeriod;
+use DateTime;
+use DeepCopy\TypeFilter\Date\DateIntervalFilter;
+use DeepCopy\TypeFilter\Date\DatePeriodFilter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \DeepCopy\TypeFilter\Date\DatePeriodFilter
+ */
+class DatePeriodFilterTest extends TestCase
+{
+    public function test_it_deep_copies_a_DatePeriod()
+    {
+        $object = new DatePeriod(new DateTime(), new DateInterval('P2D'), 3);
+
+        $filter = new DatePeriodFilter();
+
+        $copy = $filter->apply($object);
+
+        $this->assertEquals($object, $copy);
+        $this->assertNotSame($object, $copy);
+    }
+
+    public function test_it_deep_copies_a_DatePeriod_with_exclude_start_date()
+    {
+        $object = new DatePeriod(new DateTime(), new DateInterval('P2D'), 3, DatePeriod::EXCLUDE_START_DATE);
+
+        $filter = new DatePeriodFilter();
+
+        $copy = $filter->apply($object);
+
+        $this->assertEquals($object, $copy);
+        $this->assertNotSame($object, $copy);
+    }
+
+    /**
+     * @requires PHP 8.2
+     */
+    public function test_it_deep_copies_a_DatePeriod_with_include_end_date()
+    {
+        $object = new DatePeriod(new DateTime(), new DateInterval('P2D'), 3, DatePeriod::INCLUDE_END_DATE);
+
+        $filter = new DatePeriodFilter();
+
+        $copy = $filter->apply($object);
+
+        $this->assertEquals($object, $copy);
+        $this->assertNotSame($object, $copy);
+    }
+
+    public function test_it_deep_copies_a_DatePeriod_with_end_date()
+    {
+        $object = new DatePeriod(new DateTime(), new DateInterval('P2D'), new DateTime('+2 days'));
+
+        $filter = new DatePeriodFilter();
+
+        $copy = $filter->apply($object);
+
+        $this->assertEquals($object, $copy);
+        $this->assertNotSame($object, $copy);
+    }
+}


### PR DESCRIPTION
Resolves: #196 

