### PR TITLE
Fix `spl_object_hash` collision by segmenting hash db with class name

### DIFF
--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -178,10 +178,15 @@ class DeepCopy
      */
     private function copyObject($object)
     {
+        $objectClass = get_class($object);
         $objectHash = spl_object_hash($object);
 
-        if (isset($this->hashMap[$objectHash])) {
-            return $this->hashMap[$objectHash];
+        if (!isset($this->hashMap[$objectClass])) {
+            $this->hashMap[$objectClass] = [];
+        }
+
+        if (isset($this->hashMap[$objectClass][$objectHash])) {
+            return $this->hashMap[$objectClass][$objectHash];
         }
 
         $reflectedObject = new ReflectionObject($object);
@@ -189,7 +194,7 @@ class DeepCopy
 
         if (false === $isCloneable) {
             if ($this->skipUncloneable) {
-                $this->hashMap[$objectHash] = $object;
+                $this->hashMap[$objectClass][$objectHash] = $object;
 
                 return $object;
             }
@@ -203,7 +208,7 @@ class DeepCopy
         }
 
         $newObject = clone $object;
-        $this->hashMap[$objectHash] = $newObject;
+        $this->hashMap[$objectClass][$objectHash] = $newObject;
 
         if ($this->useCloneMethod && $reflectedObject->hasMethod('__clone')) {
             return $newObject;


### PR DESCRIPTION
We found an issue today at work with DeepCopy 1.11.1 which seems to be related to https://github.com/myclabs/DeepCopy/issues/180. It took me quite a good amount of time to figure this out but I hit the same problem.

There will probably never be two hashes similar for the same class but evidence from my environment shows there CAN be similar hashes across different classes.

The solution is simple, segment the hash database in memory with a class name and the problem goes away. Simple and efficient.

I did not add tests as there is not easy way to reproduce this and the hash provider we use is not a dependency we can inject.