### PR TITLE
Fix return types for Doctrine\Persistence\Proxy implementations

### DIFF
--- a/fixtures/f013/A.php
+++ b/fixtures/f013/A.php
@@ -2,6 +2,7 @@
 
 namespace DeepCopy\f013;
 
+use BadMethodCallException;
 use Doctrine\Persistence\Proxy;
 
 class A implements Proxy
@@ -11,14 +12,15 @@ class A implements Proxy
     /**
      * @inheritdoc
      */
-    public function __load()
+    public function __load(): void
     {
     }
 
     /**
      * @inheritdoc
      */
-    public function __isInitialized()
+    public function __isInitialized(): bool
     {
+        throw new BadMethodCallException();
     }
 }

--- a/fixtures/f013/B.php
+++ b/fixtures/f013/B.php
@@ -2,6 +2,7 @@
 
 namespace DeepCopy\f013;
 
+use BadMethodCallException;
 use Doctrine\Persistence\Proxy;
 
 class B implements Proxy
@@ -11,15 +12,16 @@ class B implements Proxy
     /**
      * @inheritdoc
      */
-    public function __load()
+    public function __load(): void
     {
     }
 
     /**
      * @inheritdoc
      */
-    public function __isInitialized()
+    public function __isInitialized(): bool
     {
+        throw new BadMethodCallException();
     }
 
     public function getFoo()

--- a/tests/DeepCopyTest/Matcher/Doctrine/DoctrineProxyMatcherTest.php
+++ b/tests/DeepCopyTest/Matcher/Doctrine/DoctrineProxyMatcherTest.php
@@ -39,7 +39,7 @@ class FooProxy implements Proxy
     /**
      * @inheritdoc
      */
-    public function __load()
+    public function __load(): void
     {
         throw new BadMethodCallException();
     }
@@ -47,7 +47,7 @@ class FooProxy implements Proxy
     /**
      * @inheritdoc
      */
-    public function __isInitialized()
+    public function __isInitialized(): bool
     {
         throw new BadMethodCallException();
     }


### PR DESCRIPTION
Cloning the repo and running `composer install` and `vendor/bin/phpunit` failed with:

`PHP Fatal error:  Declaration of DeepCopyTest\Matcher\Doctrine\FooProxy::__load() must be compatible with Doctrine\Persistence\Proxy::__load(): void`

This merge request adds the required return-types to `__load` (void) and `__isInitialized` (bool) of Doctrine\Persistence\Proxy implementations.