### PR TITLE
Add generic to DeepCopy::copy method

### DIFF
--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -87,9 +87,11 @@ class DeepCopy
     /**
      * Deep copies the given object.
      *
-     * @param mixed $object
+     * @template TObject of object
      *
-     * @return mixed
+     * @param TObject $object
+     *
+     * @return TObject
      */
     public function copy($object)
     {


### PR DESCRIPTION
This makes it possible for PHPStan to understand the return type.