### PR TITLE
Do not call Reflection*::setAccessible() in PHP >= 8.1

### DIFF
--- a/src/DeepCopy/DeepCopy.php
+++ b/src/DeepCopy/DeepCopy.php
@@ -267,7 +267,9 @@ class DeepCopy
             }
         }
 
-        $property->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
 
         // Ignore uninitialized properties (for PHP >7.4)
         if (method_exists($property, 'isInitialized') && !$property->isInitialized($object)) {

--- a/src/DeepCopy/Filter/Doctrine/DoctrineCollectionFilter.php
+++ b/src/DeepCopy/Filter/Doctrine/DoctrineCollectionFilter.php
@@ -19,7 +19,9 @@ class DoctrineCollectionFilter implements Filter
     {
         $reflectionProperty = ReflectionHelper::getProperty($object, $property);
 
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $oldCollection = $reflectionProperty->getValue($object);
 
         $newCollection = $oldCollection->map(

--- a/src/DeepCopy/Filter/Doctrine/DoctrineEmptyCollectionFilter.php
+++ b/src/DeepCopy/Filter/Doctrine/DoctrineEmptyCollectionFilter.php
@@ -21,7 +21,9 @@ class DoctrineEmptyCollectionFilter implements Filter
     public function apply($object, $property, $objectCopier)
     {
         $reflectionProperty = ReflectionHelper::getProperty($object, $property);
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
 
         $reflectionProperty->setValue($object, new ArrayCollection());
     }

--- a/src/DeepCopy/Filter/ReplaceFilter.php
+++ b/src/DeepCopy/Filter/ReplaceFilter.php
@@ -30,7 +30,9 @@ class ReplaceFilter implements Filter
     public function apply($object, $property, $objectCopier)
     {
         $reflectionProperty = ReflectionHelper::getProperty($object, $property);
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
 
         $value = call_user_func($this->callback, $reflectionProperty->getValue($object));
 

--- a/src/DeepCopy/Filter/SetNullFilter.php
+++ b/src/DeepCopy/Filter/SetNullFilter.php
@@ -18,7 +18,9 @@ class SetNullFilter implements Filter
     {
         $reflectionProperty = ReflectionHelper::getProperty($object, $property);
 
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $reflectionProperty->setValue($object, null);
     }
 }

--- a/src/DeepCopy/Matcher/PropertyTypeMatcher.php
+++ b/src/DeepCopy/Matcher/PropertyTypeMatcher.php
@@ -39,7 +39,9 @@ class PropertyTypeMatcher implements Matcher
             return false;
         }
 
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
 
         // Uninitialized properties (for PHP >7.4)
         if (method_exists($reflectionProperty, 'isInitialized') && !$reflectionProperty->isInitialized($object)) {


### PR DESCRIPTION
> As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.

(https://www.php.net/manual/en/reflectionmethod.setaccessible.php and https://www.php.net/manual/en/reflectionproperty.setaccessible.php).

There're even plans to deprecate the method in PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations